### PR TITLE
Remove colspan and rowspan attributes in tables with class="pr-two-column"

### DIFF
--- a/src/main/ml-modules/root/judgments/xslts/accessible-html.xsl
+++ b/src/main/ml-modules/root/judgments/xslts/accessible-html.xsl
@@ -595,9 +595,14 @@
 
 <xsl:template match="tr" mode="remove-first-column">
 	<tr>
-		<xsl:copy-of select="@*" />
-		<xsl:apply-templates select="*[position() gt 1]" />
+		<xsl:apply-templates select="*[position() gt 1]" mode="remove-first-column" />
 	</tr>
+</xsl:template>
+
+<xsl:template match="th | td" mode="remove-first-column">
+	<xsl:element name="{ local-name() }">
+		<xsl:apply-templates />
+	</xsl:element>
 </xsl:template>
 
 


### PR DESCRIPTION
This does just what the title suggests, as requested by Terry in Trello card #243