### PR TITLE
Allow recording of the Enrichment engine version

### DIFF
--- a/src/main/ml-schemas/caselaw.xsd
+++ b/src/main/ml-schemas/caselaw.xsd
@@ -22,6 +22,7 @@
 		<xs:element ref="cite" minOccurs="0"/>
 		<xs:element ref="parser"/>
 		<xs:element ref="hash"/>
+		<xs:element ref="tna-enrichment-engine"/>
 	</xs:all>
 	<xs:attributeGroup ref="akn:source"/>
 </xs:complexType>
@@ -89,6 +90,18 @@
 	</xs:simpleType>
 </xs:element>
 
+<xs:element name="tna-enrichment-engine">
+	<xs:annotation>
+		<xs:documentation>
+			<p>The version of the enrichment engine that augmented the XML</p>
+		</xs:documentation>
+	</xs:annotation>
+	<xs:simpleType>
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[0-9]+\.[0-9]+\.[0-9]+"/>
+		</xs:restriction>
+	</xs:simpleType>
+</xs:element>
 
 <!-- references -->
 


### PR DESCRIPTION
The Enrichment Engine version appears in `<proprietary><uk:tna-enrichment-engine>0.1.2</uk:tna-enrichment-engine></proprietary>` tags; we support this by permitting it in the schema.