### PR TITLE
Allow tna-enrichment-engine version to not exist

### DIFF
--- a/src/main/ml-schemas/caselaw.xsd
+++ b/src/main/ml-schemas/caselaw.xsd
@@ -22,7 +22,7 @@
 		<xs:element ref="cite" minOccurs="0"/>
 		<xs:element ref="parser"/>
 		<xs:element ref="hash"/>
-		<xs:element ref="tna-enrichment-engine"/>
+		<xs:element ref="tna-enrichment-engine" minOccurs="0"/>
 	</xs:all>
 	<xs:attributeGroup ref="akn:source"/>
 </xs:complexType>


### PR DESCRIPTION
Documents direct from the parser do not have a version for the enrichment process; the [recent schema change](https://github.com/nationalarchives/ds-caselaw-marklogic/pull/5) does not permit this.