### PR TITLE
account for default value of @colspan and @rowspan attributes

### DIFF
--- a/src/main/ml-modules/root/judgments/xslts/accessible-html.xsl
+++ b/src/main/ml-modules/root/judgments/xslts/accessible-html.xsl
@@ -582,7 +582,12 @@
 
 <xsl:function name="uk:cell-is-empty" as="xs:boolean">
 	<xsl:param name="cell" as="element()" />
-	<xsl:sequence select="empty($cell/@colspan) and empty($cell/@rowspan) and not(normalize-space(string($cell)))" />
+	<xsl:sequence select="uk:cell-span-is-effectively-one($cell/@colspan) and uk:cell-span-is-effectively-one($cell/@rowspan) and not(normalize-space(string($cell)))" />
+</xsl:function>
+
+<xsl:function name="uk:cell-span-is-effectively-one" as="xs:boolean">
+	<xsl:param name="attr" as="attribute()?" />
+	<xsl:sequence select="empty($attr) or string($attr) = '' or string($attr) = '1'" />
 </xsl:function>
 
 <xsl:template match="table" mode="remove-first-column">


### PR DESCRIPTION
The LegalDocML schema specifies a default value for a table cell's @colspan and @rowspan attributes. (That default value is 1, of course.) See line 1630 of the schema:
```
<xsd:attribute name="colspan" type="xsd:integer" default="1"/>
```

Now that we have associated documents with the schema, MarkLogic effectively adds attributes with this value at the time the XSLTs are run. Therefore, if a cell has no @colspan attribute in the XML, a test in an XSLT for the absence of this attribute will now be false, although it would have been true before the schema association. The transform had not accounted for this, but with this fix it now does.

Our XML contains no @colspan or @rolspan attribute when their value would be 1. The test in the current transform for the absence of these attributes is replaced with a new function, which returns true if any of the following is true: the attribute is missing, the attribute is empty, the attribute has a value of 1.
