### PR TITLE
Refactor inline for clarity and efficiency.

### DIFF
--- a/src/main/ml-modules/root/judgments/xslts/accessible-html.xsl
+++ b/src/main/ml-modules/root/judgments/xslts/accessible-html.xsl
@@ -401,7 +401,7 @@
 
 <xsl:function name="uk:get-combined-inline-styles" as="xs:string*">
 	<xsl:param name="e" as="element()" />
-	<xsl:variable name="from-class-attr" as="xs:string*">
+	<xsl:variable name="from-class-attr" as="xs:string*"><!-- inline formatting implied by the @class -->
 		<xsl:if test="exists($e/@class)">
 			<xsl:variable name="regex" as="xs:string" select="concat('\.', $e/@class, ' \{([^\}]+)')" />
 			<xsl:analyze-string select="$global-styles" regex="{ $regex }">
@@ -417,7 +417,7 @@
 			</xsl:analyze-string>
 		</xsl:if>
 	</xsl:variable>
-	<xsl:variable name="from-style-attr" as="xs:string*">
+	<xsl:variable name="from-style-attr" as="xs:string*"><!-- inline formatting specified in @style -->
 		<xsl:for-each select="tokenize($e/@style, ';')">
 			<xsl:variable name="prop" as="xs:string" select="normalize-space(substring-before(., ':'))" />
 			<xsl:if test="$prop = $inline-properties">
@@ -426,27 +426,37 @@
 			</xsl:if>
 		</xsl:for-each>
 	</xsl:variable>
-	<xsl:variable name="style-properties" as="xs:string*">
-		<xsl:for-each select="$from-style-attr">
-			<xsl:sequence select="substring-before(., ':')" />
+	<xsl:variable name="combined" as="xs:string*"><!-- combined, @style trumps @class -->
+		<xsl:variable name="style-properties" as="xs:string*">
+			<xsl:for-each select="$from-style-attr">
+				<xsl:sequence select="substring-before(., ':')" />
+			</xsl:for-each>
+		</xsl:variable>
+		<xsl:for-each select="$from-class-attr">
+			<xsl:variable name="prop" as="xs:string" select="substring-before(., ':')" />
+			<xsl:if test="not($prop = $style-properties)">
+				<xsl:sequence select="." />
+			</xsl:if>
 		</xsl:for-each>
+		<xsl:sequence select="$from-style-attr" />
 	</xsl:variable>
-	<xsl:for-each select="$from-class-attr">
-		<xsl:variable name="prop" as="xs:string" select="substring-before(., ':')" />
-		<xsl:if test="not($prop = $style-properties)">
-			<xsl:sequence select="." />
-		</xsl:if>
+	<!-- remove font, font-size and text-transform -->
+	<xsl:for-each select="$combined">
+		<xsl:choose>
+			<xsl:when test="starts-with(., 'font-family:') and not(contains(., 'Symbol') or contains(., 'Wingdings'))" /> <!-- remove font, except Symbol or Wingdings -->
+			<xsl:when test="starts-with(., 'font-size:')" /> <!-- remove font-size -->
+			<xsl:when test="starts-with(., 'text-transform:')" /> <!-- remove text-transform -->
+			<xsl:otherwise>
+				<xsl:sequence select="." />
+			</xsl:otherwise>
+		</xsl:choose>
 	</xsl:for-each>
-	<xsl:sequence select="$from-style-attr" />
 </xsl:function>
 
 <xsl:template name="inline">
 	<xsl:param name="name" as="xs:string" select="'span'" />
 	<xsl:param name="styles" as="xs:string*" select="uk:get-combined-inline-styles(.)" />
 	<xsl:param name="is-uppercase" as="xs:boolean" select="false()" tunnel="yes" />
-	<xsl:variable name="styles" as="xs:string*" select="$styles[not(starts-with(., 'font-size:'))]" />
-	<xsl:variable name="styles" as="xs:string*" select="$styles[not(starts-with(., 'font-family:')) or contains(., 'Symbol') or contains(., 'Wingdings')]" />
-	<xsl:variable name="styles" as="xs:string*" select="$styles[not(starts-with(., 'text-transform:'))]" />
 	<xsl:choose>
 		<xsl:when test="exists($styles[starts-with(., 'font-weight:') and not(starts-with(., 'font-weight:normal'))])">
 			<b>


### PR DESCRIPTION
Half of Refactor of https://github.com/nationalarchives/ds-caselaw-marklogic/pull/9

I've moved a bit of logic from <xsl:template name="inline"> to <xsl:function name="uk:get-combined-inline-styles"> for clarity and efficiency, as <xsl:template name="inline"> gets called recursively.