### PR TITLE
Add index for transfer-received-at

### DIFF
--- a/src/main/ml-config/databases/content-database.json
+++ b/src/main/ml-config/databases/content-database.json
@@ -23,6 +23,13 @@
     "localname": "last-modified",
     "range-value-positions" : false,
     "invalid-values": "reject"
+  },
+  {
+    "scalar-type" : "dateTime",
+    "namespace-uri": "",
+    "localname": "transfer-received-at",
+    "range-value-positions" : false,
+    "invalid-values": "ignore"
   } ],
   "word-positions": true,
   "maintain-last-modified": true,


### PR DESCRIPTION
Editors want to be able to sort by the most recently received judgment -- this requires adding an index on the database.
Image from manual staging deploy:
<img width="923" alt="image" src="https://user-images.githubusercontent.com/85497046/228591440-085871a0-1d9f-43dc-a4d5-ecf0a637e619.png">

We then can get search results for :
     ```<sort-order xmlns="http://marklogic.com/appservices/search" direction="descending" type="xs:dateTime">
        <element ns="" name="transfer-received-at" />
    </sort-order>```