### PR TITLE
Make search-v2.xqy filterable by collections (optionally)

### DIFF
--- a/src/main/ml-modules/root/judgments/search/search-v2.xqy
+++ b/src/main/ml-modules/root/judgments/search/search-v2.xqy
@@ -30,6 +30,11 @@ declare variable $only_unpublished as xs:boolean? external;
 declare variable $editor_status as xs:string? external := "";
 declare variable $editor_assigned as xs:string? external := "";
 declare variable $editor_priority as xs:string? external := "";
+declare variable $collections as xs:string? external := "";
+
+let $collection-uris := fn:tokenize($collections, ",")
+let $collection-query := if (empty($collection-uris)) then () else cts:collection-query($collection-uris)
+
 
 let $start as xs:integer := ($page - 1) * $page-size + 1
 
@@ -117,7 +122,7 @@ let $query15 := if (($show_unpublished or $only_unpublished) and $editor_status)
 ) else ()
 
 
-let $queries := ( $query1, $query2, $query4, $query5, $query6, $query7, $query8, $query9, $query10, $query11, $query12, $query13, $query14, $query15, dls:documents-query() )
+let $queries := ( $collection-query, $query1, $query2, $query4, $query5, $query6, $query7, $query8, $query9, $query10, $query11, $query12, $query13, $query14, $query15, dls:documents-query() )
 let $query := cts:and-query($queries)
 
 let $show-snippets as xs:boolean := exists(( $query1, $query2, $query5 ))


### PR DESCRIPTION
**Ticket:** https://trello.com/c/T6x6GXmc/803-ensure-judgments-dont-display-press-summaries-erroneously


**Change**:
- Adds an optional input parameter "collections" to `search-v2.xqy` which should be given as a comma separated list of collection uris. 

The collections passed in must not have spaces in them (since they must be valid uris).

If the collection uris passed in dont have any docs in them, then we will return nothing.

We can pass in multiple collections - in that case we will get a combination of all docs that reside in at least one of the collections.

Defaults to empty string, "", in that case query wont filter by collections at all.

**Note:** 
This PR should be able to be merged in, published and integrated into all clients with no change due to the optional nature of this parameter. Next step will be to migrate all current documents, which should just be judgments to be part of a "judgments" collection, so we can then adjust the clients to filter by "judgments" in preparation for us adding press summaries into the system.


**Testing**:

Have tested in marklogic console by replacing the input parameter declarations with some basic values:


```
xquery version "1.0-ml";

import module namespace search = "http://marklogic.com/appservices/search" at "/MarkLogic/appservices/search/search.xqy";
import module namespace helper = "https://caselaw.nationalarchives.gov.uk/helper" at "/judgments/search/helper.xqy";
import module namespace dls = "http://marklogic.com/xdmp/dls" at "/MarkLogic/dls.xqy";

declare namespace akn = "http://docs.oasis-open.org/legaldocml/ns/akn/3.0";
declare namespace uk = "https://caselaw.nationalarchives.gov.uk";

declare function uk:get-request-date($name as xs:string) as xs:date? {
    let $raw := $name
    return if ($raw castable as xs:date) then xs:date($raw) else ()
};


let $q := ()
let $party := ()
let $court := ()
let $judge := ()
let $neutral_citation := ()
let $specific_keyword := ()
let $order := ()
let $page := 1
let $page-size := 10
let $from := ()
let $to := ()
let $from_date := uk:get-request-date($from)
let $to_date := uk:get-request-date($to)
let $show_unpublished := ()
let $only_unpublished := ()
let $editor_status := ""
let $editor_assigned := ""
let $editor_priority := ""


let $collections := "blah,judgments"
let $collection-uris := fn:tokenize($collections, ",")
let $collection-query := if (empty($collection-uris)) then () else cts:collection-query($collection-uris)


let $start as xs:integer := ($page - 1) * $page-size + 1

let $params := map:map()
    => map:with('q', $q)
    => map:with('party', $party)
    => map:with('court', $court)
    => map:with('judge', $judge)
    => map:with('neutral_citation', $neutral_citation)
    => map:with('specific_keyword', $specific_keyword)
    => map:with('page', $page)
    => map:with('page-size', $page-size)
    => map:with('order', $order)
    => map:with('from', $from)
    => map:with('to', $to)
    => map:with('show_unpublished', $show_unpublished)
    => map:with('only_unpublished', $only_unpublished)
    => map:with('editor_status', $editor_status)
    => map:with('editor_assigned', $editor_assigned)
    => map:with('editor_priority', $editor_priority)

let $query1 := if ($q and not(helper:is-a-consignment-number($q))) then (helper:make-q-query($q)) else ()
let $query2 := if ($party) then
    cts:or-query((
        cts:element-word-query(fn:QName('http://docs.oasis-open.org/legaldocml/ns/akn/3.0', 'party'), $party),
        cts:element-attribute-word-query(fn:QName('http://docs.oasis-open.org/legaldocml/ns/akn/3.0', 'FRBRname'), fn:QName('', 'value'), $party)
    ))
else ()

let $query4 := if ($court) then cts:or-query(
    for $c in json:array-values($court) return (
    cts:element-value-query(fn:QName('https://judgments.gov.uk/', 'court'), $c, ('case-insensitive')),
    cts:element-value-query(fn:QName('https://caselaw.nationalarchives.gov.uk/akn', 'court'), $c, ('case-insensitive')),
    cts:element-attribute-word-query(
    fn:QName('http://docs.oasis-open.org/legaldocml/ns/akn/3.0', 'FRBRuri'), xs:QName('value'), $c, ('case-insensitive')
    )
)) else ()


let $query5 := if ($judge) then cts:element-word-query(fn:QName('http://docs.oasis-open.org/legaldocml/ns/akn/3.0', 'judge'), $judge, ('case-insensitive', 'punctuation-insensitive')) else ()
let $query6 := if (empty($from_date)) then () else cts:path-range-query('akn:FRBRWork/akn:FRBRdate/@date', '>=', $from_date)
let $query7 := if (empty($to_date)) then () else cts:path-range-query('akn:FRBRWork/akn:FRBRdate/@date', '<=', $to_date)
let $query8 := if ($show_unpublished or $only_unpublished) then () else cts:properties-fragment-query(cts:element-value-query(fn:QName("", "published"), "true"))
let $query9 := if ($only_unpublished) then cts:properties-fragment-query(cts:not-query(cts:element-value-query(fn:QName("", "published"), "true"))) else ()
let $query10 := if ($neutral_citation) then
    cts:element-value-query(fn:QName('https://caselaw.nationalarchives.gov.uk/akn', 'cite'), $neutral_citation, ('case-insensitive'))
else ()
let $query11 := if ($specific_keyword) then
    cts:word-query($specific_keyword, ('case-insensitive', 'unstemmed'))
else ()
let $query12 := if (helper:is-a-consignment-number($q)) then (helper:make-consignment-number-query($q)) else ()
let $query13 := if (($show_unpublished or $only_unpublished) and $editor_assigned) then cts:properties-fragment-query(cts:element-value-query(fn:QName("", "assigned-to"), $editor_assigned)) else ()
let $query14 := if (($show_unpublished or $only_unpublished) and $editor_priority) then cts:properties-fragment-query(cts:element-value-query(fn:QName("", "editor-priority"), $editor_priority)) else ()

let $status_new_query := cts:properties-fragment-query(cts:not-query(
    cts:element-value-query(fn:QName("", "assigned-to"), "*", "wildcarded")
    ))

(: currently there is no way to get an empty assigned-to, but that's a bug :)
(: let $empty_assignment_query := cts:properties-fragment-query(
    cts:element-value-query(fn:QName("", "assigned-to"), "")
    ) :)

let $status_held_query := cts:properties-fragment-query(
    cts:and-query((
        cts:element-value-query(fn:QName("", "editor-hold"), "true"),
        cts:element-value-query(fn:QName("", "assigned-to"), "*", "wildcarded")
    ))
)
let $status_progress_query := cts:properties-fragment-query(
    cts:and-query((
        (: does this include no editor-hold? :)
        cts:not-query(cts:element-value-query(fn:QName("", "editor-hold"), "true")),
        cts:element-value-query(fn:QName("", "assigned-to"), "*", "wildcarded")
    ))
)


let $query15 := if (($show_unpublished or $only_unpublished) and $editor_status) then (
    if ($editor_status = 'new') then ($status_new_query) else (
        if ($editor_status = 'held') then ($status_held_query) else (
            if ($editor_status = 'inprogress') then ($status_progress_query) else ()
        )
    )
) else ()


let $queries := ( $collection-query, $query1, $query2, $query4, $query5, $query6, $query7, $query8, $query9, $query10, $query11, $query12, $query13, $query14, $query15, dls:documents-query() )
let $query := cts:and-query($queries)

let $show-snippets as xs:boolean := exists(( $query1, $query2, $query5 ))

let $sort-order := if ($order = 'date') then
    <sort-order xmlns="http://marklogic.com/appservices/search" direction="ascending">
        <path-index xmlns:akn="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">akn:FRBRWork/akn:FRBRdate/@date</path-index>
    </sort-order>
else if ($order = '-date') then
    <sort-order xmlns="http://marklogic.com/appservices/search" direction="descending">
        <path-index xmlns:akn="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">akn:FRBRWork/akn:FRBRdate/@date</path-index>
    </sort-order>
else if ($order = '-updated') then
     <sort-order xmlns="http://marklogic.com/appservices/search" direction="descending" type="xs:dateTime">
        <element ns="http://marklogic.com/xdmp/property" name="last-modified" />
    </sort-order>
else if ($order = 'updated') then
    <sort-order xmlns="http://marklogic.com/appservices/search" direction="ascending" type="xs:dateTime">
        <element ns="http://marklogic.com/xdmp/property" name="last-modified" />
    </sort-order>
else if ($order = '-transformation') then
    <sort-order xmlns="http://marklogic.com/appservices/search" direction="ascending">
        <path-index xmlns:akn="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">akn:akomaNtoso/akn:judgment/akn:meta/akn:identification/akn:FRBRManifestation/akn:FRBRdate[@name='transform']/@date</path-index>
    </sort-order>
else if ($order = 'transformation') then
    <sort-order xmlns="http://marklogic.com/appservices/search" direction="descending">
        <path-index xmlns:akn="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">akn:akomaNtoso/akn:judgment/akn:meta/akn:identification/akn:FRBRManifestation/akn:FRBRdate[@name='transform']/@date</path-index>
    </sort-order>
else
    ()

let $transform-results := if ($show-snippets) then
    $helper:transform-results
else
    <transform-results xmlns="http://marklogic.com/appservices/search" apply="empty-snippet" />


let $scope := if ($order = 'updated') then
    'properties'
else if ($order = '-updated') then
    'properties'
else
    'documents'


let $search-options := <options xmlns="http://marklogic.com/appservices/search">
    <fragment-scope>{ $scope }</fragment-scope>
    <search-option>unfiltered</search-option>
    { $sort-order }
    <extract-document-data xmlns:akn="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
        <extract-path>//akn:FRBRWork/akn:FRBRdate</extract-path>
        <extract-path>//akn:FRBRWork/akn:FRBRname</extract-path>
        <extract-path>//uk:cite</extract-path>
        <extract-path>//akn:neutralCitation</extract-path>
        <extract-path>//uk:court</extract-path>
        <extract-path>//uk:hash</extract-path>
        <extract-path>//akn:FRBRManifestation/akn:FRBRdate</extract-path>
    </extract-document-data>
    { $transform-results }
</options>

let $results := search:resolve(element x { $query }/*, $search-options, $start, $page-size)
let $total as xs:integer := xs:integer($results/@total)
let $pages as xs:integer := if ($total mod $page-size eq 0) then $total idiv $page-size else $total idiv $page-size + 1
let $params := $params => map:with('pages', $pages)

return $results

```