### PR TITLE
README and scripts changes after installing from scratch

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,13 @@ This folder specifies the configuration of the Marklogic database used by the Ca
 It uses the [ml-gradle](https://github.com/marklogic/ml-gradle) to manage and maintain a versioned configuration.
 
 For full details of what can be set in the files here, see the [ml-gradle documentation](https://github.com/marklogic-community/ml-gradle/wiki).
-The file layout is explaines in the [project layout documentation](https://github.com/marklogic-community/ml-gradle/wiki/Project-layout).
+The file layout is explained in the [project layout documentation](https://github.com/marklogic-community/ml-gradle/wiki/Project-layout).
 
 ## Setup
 
-1. Access to the Marklogic Docker image is restricted to those who have 'purchased' it on Docker Hub. It's actually FREE to purchase, but you need to fill out [a short form](https://hub.docker.com/_/marklogic/purchase).
+1. Install `gradle`. On MacOS, you can use `brew install gradle`.
 
-2. Install `gradle`. On MacOS, you can use `brew install gradle`.
-
-3. If you're running against anything other than development, copy `gradle-development.properties`
+2. If you're running against anything other than development, copy `gradle-development.properties`
 to `gradle-{environment}.properties` and set the credentials and hostname for your Marklogic server.
 
 ## Deployment
@@ -31,7 +29,7 @@ Deployment is idempotent, and will automatically configure databases, roles, tri
 
 ### 1. Run a marklogic docker container
 
-A `docker-compose.yml` file for running Marklogic locally is included. Run `docker-compose up -d` to start it; it takes about a minute, and will raise various HTTP errors if you visit `localhost:8000` before that point.
+A `docker-compose.yml` file for running Marklogic locally is included. Run `docker-compose up -d` to start it; it takes a minute or so, and will raise various HTTP errors if you visit `localhost:8000` before that point.
 
 Note: There is currently a [known issue](https://github.com/marklogic/marklogic-docker/issues/212) with [marklogic-docker](https://github.com/marklogic/marklogic-docker) so instead you might need to run `development_scripts/run_local_docker`
 

--- a/development_scripts/populate_from_caselaw.py
+++ b/development_scripts/populate_from_caselaw.py
@@ -1,3 +1,4 @@
+#!python3
 """
 This script retrieves XML data from the live TNA caselaw website and updates a local MarkLogic database.
 
@@ -35,4 +36,3 @@ for url in urls:
     )
     response.raise_for_status()
     print("added to local Marklogic db")
-


### PR DESCRIPTION
* you don't need to "buy" marklogic any more
* readded shebang with python3 this time, could have `chmod -x`-ed it instead.