### PR TITLE
Add a gradle script to batch add all documents to the 'judgments' collection

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,16 @@ task publishAllDocuments(type: com.marklogic.gradle.task.CorbTask, dependsOn: ['
   threadCount = 16
 }
 
+
+task addAllDocumentsToJudgmentsCollection(type: com.marklogic.gradle.task.CorbTask, dependsOn: ['mlLoadModules']) {
+  xccConnectionUri = contentXccUrl
+  xccHttpcompliant = true
+  moduleRoot = "/judgments/corb/"
+  modulePrefix = "add-all-documents-to-judgments-collection"
+  threadCount = 16
+}
+
+
 task importDocuments(type: com.marklogic.gradle.task.MlcpTask, dependsOn: ['mlLoadModules']) {
   classpath = configurations.mlcp
   command = "IMPORT"

--- a/src/main/ml-modules/root/judgments/corb/add-all-documents-to-judgments-collection-transform.xqy
+++ b/src/main/ml-modules/root/judgments/corb/add-all-documents-to-judgments-collection-transform.xqy
@@ -1,0 +1,7 @@
+xquery version '1.0-ml';
+
+import module namespace dls = "http://marklogic.com/xdmp/dls" at "/MarkLogic/dls.xqy";
+
+declare variable $URI as xs:string external;
+
+dls:document-add-collections($URI, "judgment")

--- a/src/main/ml-modules/root/judgments/corb/add-all-documents-to-judgments-collection-uris.xqy
+++ b/src/main/ml-modules/root/judgments/corb/add-all-documents-to-judgments-collection-uris.xqy
@@ -1,0 +1,6 @@
+xquery version "1.0-ml";
+
+import module namespace dls = "http://marklogic.com/xdmp/dls" at "/MarkLogic/dls.xqy";
+
+let $uris := cts:uris("", (), dls:documents-query())
+return (fn:count($uris), $uris)


### PR DESCRIPTION
This is useful after batch importing from production, when they would be invisible otherwise.