### PR TITLE
remove MathML namespace

### DIFF
--- a/src/main/ml-modules/root/judgments/xslts/accessible-html.xsl
+++ b/src/main/ml-modules/root/judgments/xslts/accessible-html.xsl
@@ -900,10 +900,10 @@
 <!-- math -->
 
 <xsl:template match="math:*">
-	<xsl:copy>
+	<xsl:element name="{ local-name(.) }">
 		<xsl:copy-of select="@*"/>
 		<xsl:apply-templates />
-	</xsl:copy>
+	</xsl:element>
 </xsl:template>
 
 


### PR DESCRIPTION
This tiny fix simply removes the namespace from MathML elements.

Previously, an element such as `<mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" />` would appear exactly the same in the HTML. Now it will be replaced with a simple `<math />`.