### PR TITLE
Fix for styles in press summaries

### DIFF
--- a/src/main/ml-modules/root/judgments/xslts/accessible-html.xsl
+++ b/src/main/ml-modules/root/judgments/xslts/accessible-html.xsl
@@ -333,9 +333,13 @@
 		<xsl:when test="$doc-id = 'ewhc/ch/2022/1178'">
 			<xsl:sequence select="uk:make-class-selector-for-ewhc-ch-2022-1178($context, $e)" />
 		</xsl:when>
-		<!-- the selector for main styles is '#judgment .{ClassName}', e.g., '#judgment .ParaLevel1' -->
+		<!-- the selector for main styles in a judgment is '#judgment .{ClassName}', e.g., '#judgment .ParaLevel1' -->
 		<xsl:when test="$context/self::judgment">
 			<xsl:sequence select="concat('#judgment .', $e/@class)" />
+		</xsl:when>
+		<!-- the selector for main styles in a press summary is '#main .{ClassName}', e.g., '#main .ParaLevel1' -->
+		<xsl:when test="$context/self::doc[@name='pressSummary']">
+			<xsl:sequence select="concat('#main .', $e/@class)" />
 		</xsl:when>
 		<!-- the selector for attachment styles is '#{type}{num} .{ClassName}', e.g., '#order1 .ParaLevel1' -->
 		<xsl:otherwise>


### PR DESCRIPTION
This is a very small change to the HTML transform, allowing it to find the CSS class definitions in the metadata of a press summary.

In press summaries, the parser adds the string '#main' before the name of the Word style. For example, style 'Paragraph1' might be '#main .Paragraph1 { font-style: bold }' in the Akmoa Ntoso metadata.

This differs from a judgment, in which the main styles are preceded by '#judgment'.

I just forgot to update the HTML transform for press summaries. This fix should do that.