### PR TITLE
Add xdmp-sql privilege to editor user

### DIFF
--- a/src/main/ml-config/security/roles/8-caselaw-execute-sql.json
+++ b/src/main/ml-config/security/roles/8-caselaw-execute-sql.json
@@ -1,0 +1,12 @@
+{
+  "role-name" : "caselaw-execute-sql",
+  "description" : "Can execute SQL queries against the database over XDMP",
+  "role" : [ ],
+  "privilege": [
+    {
+      "privilege-name": "can-execute-sql",
+      "kind": "execute",
+      "action": "http://marklogic.com/xdmp/privileges/xdmp-sql"
+    }
+  ]
+}

--- a/src/main/ml-config/security/users/caselaw-editor-ui.json
+++ b/src/main/ml-config/security/users/caselaw-editor-ui.json
@@ -1,5 +1,5 @@
 {
   "user-name" : "caselaw-editor-ui",
   "description" : "The Editor UI reader & writer",
-  "role" : [ "dls-admin", "rest-writer", "caselaw-unpublished-reader", "caselaw-writer" ]
+  "role" : [ "dls-admin", "rest-writer", "caselaw-unpublished-reader", "caselaw-writer", "caselaw-execute-sql" ]
 }


### PR DESCRIPTION
This creates a new `caselaw-execute-sql` role with the `xdmp-sql` privilege, and assigns it to the `caselaw-editor-ui` user.