### PR TITLE
Allow searching for multiple judges in a single query

### DIFF
--- a/src/main/ml-modules/root/judgments/search/search-v2.xqy
+++ b/src/main/ml-modules/root/judgments/search/search-v2.xqy
@@ -74,7 +74,14 @@ let $query4 := if ($court) then cts:or-query(
 )) else ()
 
 
-let $query5 := if ($judge) then cts:element-word-query(fn:QName('http://docs.oasis-open.org/legaldocml/ns/akn/3.0', 'judge'), $judge, ('case-insensitive', 'punctuation-insensitive')) else ()
+let $judge_elements := fn:tokenize($judge, ",")
+
+let $judge_query := cts:or-query(fn:map(function($j) {
+  cts:element-word-query(fn:QName('http://docs.oasis-open.org/legaldocml/ns/akn/3.0', 'judge'), $j, ('case-insensitive', 'punctuation-insensitive'))
+}, $judge_elements))
+
+let $query5 := if ($judge) then $judge_query else ()
+
 let $query6 := if (empty($from_date)) then () else cts:path-range-query('akn:judgment/akn:meta/akn:identification/akn:FRBRWork/akn:FRBRdate/@date', '>=', $from_date)
 let $query7 := if (empty($to_date)) then () else cts:path-range-query('akn:judgment/akn:meta/akn:identification/akn:FRBRWork/akn:FRBRdate/@date', '<=', $to_date)
 let $query8 := if ($show_unpublished or $only_unpublished) then () else cts:properties-fragment-query(cts:element-value-query(fn:QName("", "published"), "true"))


### PR DESCRIPTION
## Changes in this PR

This is to satisfy a specific request from the judicial working group - they've asked for the ability to do a limited 'boolean-OR' search specifically on the 'judge name' field, in order to be able to find all judgments by a judge who may have changed their name. This change transparently allows this - the field is separated on commas and combined in a boolean or-expression. Existing publicly announced behaviour is not affected, but those that know the trick can use commas!

## Trello card

https://trello.com/c/uhBHQPVS/1510-search-judge-metadata-box-to-allow-or-searching-on-the-dl-by-feb

## Screenshots

### Before
<img width="1270" alt="Screenshot 2023-11-29 at 14 03 08" src="https://github.com/nationalarchives/ds-caselaw-marklogic/assets/4279/1cb00860-224b-4c1a-a997-c84c38da5328">


### After
<img width="1270" alt="Screenshot 2023-11-29 at 13 50 02" src="https://github.com/nationalarchives/ds-caselaw-marklogic/assets/4279/b17c6dad-43bb-4f63-bf70-521016de5be7">
