### PR TITLE
Add optional uk:jurisdiction to the schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ The `development` environment will be used by default if you don't specify `-Pen
 
 Deployment is idempotent, and will automatically configure databases, roles, triggers and modules.
 
+Please also create a Github Release when you deploy.
+
 ## Local Setup
 
 ### 1. Run a marklogic docker container

--- a/src/main/ml-schemas/caselaw.xsd
+++ b/src/main/ml-schemas/caselaw.xsd
@@ -20,6 +20,7 @@
 		<xs:element ref="year" minOccurs="0"/>
 		<xs:element ref="number" minOccurs="0"/>
 		<xs:element ref="cite" minOccurs="0"/>
+		<xs:element ref="jurisdiction" minOccurs="0"/>
 		<xs:element ref="parser"/>
 		<xs:element ref="hash"/>
 		<xs:element ref="tna-enrichment-engine" minOccurs="0"/>
@@ -60,6 +61,14 @@
 	<xs:annotation>
 		<xs:documentation>
 			<p>The neutral citation</p>
+		</xs:documentation>
+	</xs:annotation>
+</xs:element>
+
+<xs:element name="jurisdiction" type="xs:string">
+  <xs:annotation>
+	  <xs:documentation>
+		  <p>The subfield of the court</p>
 		</xs:documentation>
 	</xs:annotation>
 </xs:element>


### PR DESCRIPTION
Validates https://caselaw.nationalarchives.gov.uk/id/ukftt/grc/2023/1024, which in turn confirms the xsd is valid.