### PR TITLE
Swap to only doing TDE on latest versions for process data

### DIFF
--- a/src/main/ml-schemas/tde/sql-process-extract.xml
+++ b/src/main/ml-schemas/tde/sql-process-extract.xml
@@ -3,8 +3,7 @@
   xmlns="http://marklogic.com/xdmp/tde">
   <context>//akn:FRBRWork</context>
   <collections>
-    <collection>press-summary</collection>
-    <collection>judgment</collection>
+    <collection>http://marklogic.com/collections/dls/latest-version</collection>
   </collections>
   <path-namespaces>
     <path-namespace>


### PR DESCRIPTION
The current TDE template extracts all versions of documents, but we only care about the latest versions.