### PR TITLE
Prioritise quoted phrases in search result snippets.

### DIFF
--- a/src/main/ml-modules/root/judgments/search/search-v2.xqy
+++ b/src/main/ml-modules/root/judgments/search/search-v2.xqy
@@ -31,6 +31,7 @@ declare variable $editor_status as xs:string? external := "";
 declare variable $editor_assigned as xs:string? external := "";
 declare variable $editor_priority as xs:string? external := "";
 declare variable $collections as xs:string? external := "";
+declare variable $quoted_phrases as json:array? external := xdmp:from-json-string("[]");
 
 let $collection-uris := fn:tokenize($collections, ",")
 let $collection-query := if (empty($collection-uris)) then () else cts:collection-query($collection-uris)
@@ -55,6 +56,7 @@ let $params := map:map()
     => map:with('editor_status', $editor_status)
     => map:with('editor_assigned', $editor_assigned)
     => map:with('editor_priority', $editor_priority)
+    => map:with('quoted_phrases', $quoted_phrases)
 
 let $query1 := if ($q and not(helper:is-a-consignment-number($q))) then (helper:make-q-query($q)) else ()
 let $query2 := if ($party) then
@@ -154,7 +156,7 @@ let $sort-word := replace($order, '-', '')
         ()
 
 let $transform-results := if ($show-snippets) then
-    $helper:transform-results
+    helper:snippet-transform-results($quoted_phrases)
 else
     <transform-results xmlns="http://marklogic.com/appservices/search" apply="empty-snippet" />
 


### PR DESCRIPTION
# Changes in this PR 

This ensures that the returned result snippets prioritise snippets which contain quoted phrases from the search query.

It depends on an [associated PR](https://github.com/nationalarchives/ds-caselaw-custom-api-client/pull/526) on API client for a couple of reasons:

First, we need to pass through the quoted phrases in the search from the client (Marklogic's regexp engine isn't up to the task, sadly) and secondly, this transforms the snippet results after they are returned, and therefore we need to up the maximum number of snippets returned in order to make sure that we can pick out the ones we want. The changes in the API client ensure that only the first 4 snippets are displayed, to maintain the current behaviour.

## Trello card

https://trello.com/c/IQK3v7c5/1560-search-matching-text-should-reflect-search-query-in-quotations-over-other-words-in-search-results