### PR TITLE
add support for <embeddedStructure> element

### DIFF
--- a/src/main/ml-modules/root/judgments/xslts/accessible-html.xsl
+++ b/src/main/ml-modules/root/judgments/xslts/accessible-html.xsl
@@ -263,6 +263,19 @@
 	</p>
 </xsl:template>
 
+<!-- quoted structures -->
+
+<xsl:template match="block[@name='embeddedStructure']">
+	<xsl:apply-templates />
+</xsl:template>
+
+<xsl:template match="embeddedStructure">
+	<blockquote>
+		<xsl:apply-templates />
+	</blockquote>
+</xsl:template>
+
+
 <!-- CSS classes -->
 
 <!-- sets the ancestor document element containing the CSS style for its descendants -->
@@ -543,19 +556,6 @@
 	<p>
 		<xsl:call-template name="inline" />
 	</p>
-</xsl:template>
-
-<xsl:template match="level/*/p[@class='Quote']">
-	<div class="judgment-body__section">
-		<span class="judgment-body__number"></span>
-		<div class="judgment-body__text">
-			<blockquote>
-				<p>
-					<xsl:call-template name="inline" />
-				</p>
-			</blockquote>
-		</div>
-	</div>
 </xsl:template>
 
 <xsl:template match="block">


### PR DESCRIPTION
I will soon make a change to the XML, and it will contain a new element \<embeddedStructure\> surrounding block quotes.

This fix just adds support for it. Essentially it maps it to a \<blockquote\> in HTML.

Also, I remove an old template, which was always a bit of a hack, which added a \<blockquote\> element based on the class of a paragraph. Hopefully, that template will be unnecessary now.