### PR TITLE
Validate XML schemas using pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,16 @@ repos:
       - id: check-yaml
       - id: check-xml
 
+  - repo: local
+    hooks:
+      - id: validate-schemas
+        name: validate-schemas
+        language: python
+        additional_dependencies:
+          - xmlschema
+        entry: python scripts/validate_schemas
+        files: .xsd$
+
   - repo: https://github.com/psf/black
     rev: 23.11.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,7 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
+      - id: check-xml
 
   - repo: https://github.com/psf/black
     rev: 23.11.0

--- a/scripts/validate_schemas
+++ b/scripts/validate_schemas
@@ -1,0 +1,9 @@
+#!/usr/bin/python3
+
+from xmlschema import XMLSchema
+
+import sys
+
+for file in sys.argv[1:]:
+    print(f"Validating {file}")
+    XMLSchema.meta_schema.validate(file)


### PR DESCRIPTION
We recently managed to commit a schema which was valid XML, but which was not a valid schema.

This makes two tweaks to pre-commit:
- Use the pre-commit default `check-xml` hook to quickly check that all our XML files are actually syntactically valid in the first place.
- Add a new `validate_schemas` script and pre-commit hook which uses [xmlschema](https://github.com/sissaschool/xmlschema/tree/master) to validate that `.xsd` files are actually valid XML schemas.