### PR TITLE
include jurisdiction in search result xml

### DIFF
--- a/src/main/ml-modules/root/judgments/search/search-v2.xqy
+++ b/src/main/ml-modules/root/judgments/search/search-v2.xqy
@@ -174,6 +174,7 @@ let $search-options := <options xmlns="http://marklogic.com/appservices/search">
         <extract-path>//uk:cite</extract-path>
         <extract-path>//akn:neutralCitation</extract-path>
         <extract-path>//uk:court</extract-path>
+        <extract-path>//uk:jurisdiction</extract-path>
         <extract-path>//uk:hash</extract-path>
         <extract-path>//akn:FRBRManifestation/akn:FRBRdate</extract-path>
     </extract-document-data>


### PR DESCRIPTION
 A little oversight in the GRC jurisdiction work - we need the jurisdiction to be present in the search result xml, if available!