### PR TITLE
(1751) Add range path indexes to support faceted search on court and year

### DIFF
--- a/src/main/ml-config/databases/content-database.json
+++ b/src/main/ml-config/databases/content-database.json
@@ -5,6 +5,10 @@
   "path-namespace" : [ {
     "prefix": "akn",
     "namespace-uri" : "http://docs.oasis-open.org/legaldocml/ns/akn/3.0"
+  },
+  {
+    "prefix": "uk",
+    "namespace-uri" : "https://caselaw.nationalarchives.gov.uk/akn"
   } ],
   "range-path-index" : [ {
     "scalar-type" : "date",
@@ -14,6 +18,12 @@
   }, {
     "scalar-type": "dateTime",
     "path-expression" : "akn:akomaNtoso/akn:judgment/akn:meta/akn:identification/akn:FRBRManifestation/akn:FRBRdate[@name='transform']/@date",
+    "range-value-positions" : false,
+    "invalid-values": "ignore"
+  }, {
+    "scalar-type": "string",
+    "path-expression" : "//akn:proprietary/uk:court",
+    "collation" : "http://marklogic.com/collation/",
     "range-value-positions" : false,
     "invalid-values": "ignore"
   } ],

--- a/src/main/ml-config/databases/content-database.json
+++ b/src/main/ml-config/databases/content-database.json
@@ -26,6 +26,11 @@
     "collation" : "http://marklogic.com/collation/",
     "range-value-positions" : false,
     "invalid-values": "ignore"
+  }, {
+    "scalar-type": "gYear",
+    "path-expression" : "//akn:proprietary/uk:year",
+    "range-value-positions" : false,
+    "invalid-values": "ignore"
   } ],
   "range-element-index": [ {
     "scalar-type" : "dateTime",

--- a/src/main/ml-modules/root/judgments/search/search-v2.xqy
+++ b/src/main/ml-modules/root/judgments/search/search-v2.xqy
@@ -173,6 +173,12 @@ let $search-options := <options xmlns="http://marklogic.com/appservices/search">
             <path-index xmlns:akn="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">//akn:proprietary/uk:court</path-index>
         </range>
     </constraint>
+    <constraint name="year">
+        <range type="xs:gYear" facet="true">
+            <facet-option>limit=10</facet-option>
+            <path-index xmlns:akn="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">//akn:proprietary/uk:year</path-index>
+        </range>
+    </constraint>
     { $sort-order }
     <extract-document-data xmlns:akn="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
         <extract-path>//akn:FRBRWork/akn:FRBRdate</extract-path>

--- a/src/main/ml-modules/root/judgments/search/search-v2.xqy
+++ b/src/main/ml-modules/root/judgments/search/search-v2.xqy
@@ -167,6 +167,12 @@ let $scope := 'documents'
 let $search-options := <options xmlns="http://marklogic.com/appservices/search">
     <fragment-scope>{ $scope }</fragment-scope>
     <search-option>unfiltered</search-option>
+    <constraint name="court">
+        <range type="xs:string" facet="true">
+            <facet-option>limit=10</facet-option>
+            <path-index xmlns:akn="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">//akn:proprietary/uk:court</path-index>
+        </range>
+    </constraint>
     { $sort-order }
     <extract-document-data xmlns:akn="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
         <extract-path>//akn:FRBRWork/akn:FRBRdate</extract-path>


### PR DESCRIPTION
We want to support faceted search, where users can narrow down their results by selecting the court and the year most likely to be relevant to their search.

MarkLogic supports facets, so what we need to do is define the range path indexes for court and year, and add the facet options to the search options as `constraint`s.

Faceted search will first be released behind a feature flag on the public UI site, and tested with users.

[Trello](https://trello.com/c/XMzUM1jX/1751-🏠🎛-homepage2-faceted-search-concept-on-staging-for-testing-courtyear)
