### PR TITLE
more footnote classes and hidden footnote text

### DIFF
--- a/src/main/ml-modules/root/judgments/xslts/accessible-html.xsl
+++ b/src/main/ml-modules/root/judgments/xslts/accessible-html.xsl
@@ -877,17 +877,19 @@
 
 <xsl:template match="authorialNote">
 	<xsl:variable name="marker" as="xs:string" select="@marker" />
-	<a id="{ concat('fnref', $marker) }" class="judgment-body__footnote-reference" href="{ concat('#fn', $marker) }">
+	<a id="{ concat('fnref', $marker) }" href="{ concat('#fn', $marker) }" class="judgment-body__footnote-reference">
+		<span class="judgment__hidden"> (Footnote: </span>
 		<sup>
 			<xsl:value-of select="$marker" />
 		</sup>
+		<span class="judgment__hidden">)</span>
 	</a>
 </xsl:template>
 
 <xsl:template name="footnotes">
 	<xsl:param name="footnotes" as="element()*" select="descendant::authorialNote" />
 	<xsl:if test="exists($footnotes)">
-		<footer>
+		<footer class="judgment-footer">
 			<hr />
 			<xsl:apply-templates select="$footnotes" mode="footnote" />
 		</footer>
@@ -902,11 +904,13 @@
 
 <xsl:template match="authorialNote/p[1]">
 	<xsl:variable name="marker" as="xs:string" select="../@marker" />
-	<p id="{ concat('fn', $marker) }">
-		<a href="{ concat('#fnref', $marker) }" class="judgment-body__footnote-reference">
+	<p id="{ concat('fn', $marker) }" class="judgment-footer__footnote">
+		<a href="{ concat('#fnref', $marker) }" class="judgment-footer__footnote-backlink">
+			<span class="judgment__hidden"> (Footnote reference from: </span>
 			<sup>
 				<xsl:value-of select="$marker" />
 			</sup>
+			<span class="judgment__hidden">)</span>
 		</a>
 		<xsl:text> </xsl:text>
 		<xsl:call-template name="inline" />


### PR DESCRIPTION
These are the changes requested by Tim in FCL-41. Footnote markup will now look like this:
```html
<p>
  Some body text.
  <a id="fnref1" href="#fn1" class="judgment-body__footnote-reference">
    <span class="judgment__hidden"> (Footnote: </span>
    <sup>1</sup>
    <span class="judgment__hidden">)</span>
  </a>
</p>
````

and

```html
<footer class="judgment-footer">
  <hr>
  <div>
    <p id="fn1" class="judgment-footer__footnote">
      <a href="#fnref1" class="judgment-footer__footnote-backlink">
        <span class="judgment__hidden"> (Footnote reference from: </span>
        <sup>1</sup>
        <span class="judgment__hidden">)</span>
      </a>
      Some footnote text.
    </p>
  </div>
  ...
</footer>
```