### PR TITLE
Recognize crests following restrictions

### DIFF
--- a/src/main/ml-modules/root/judgments/xslts/accessible-html.xsl
+++ b/src/main/ml-modules/root/judgments/xslts/accessible-html.xsl
@@ -469,7 +469,7 @@
 <xsl:template match="header//p[not(parent::blockContainer)][not(ancestor::authorialNote)]">
 	<xsl:param name="class-context" as="element()" tunnel="yes" />
 	<xsl:choose>
-		<xsl:when test="empty(preceding-sibling::*) and exists(child::img)">
+		<xsl:when test="exists(child::img) and (every $block in preceding-sibling::* satisfies $block/@name = 'restriction')">
 			<div class="judgment-header__logo">
 				<xsl:apply-templates>
 					<xsl:with-param name="has-underline" select="()" tunnel="yes" />


### PR DESCRIPTION
Previously, the transform would apply the "judgment-header__logo" class only to paragraphs with images and with no preceding siblings.

This change allows it to be applied even if the paragraph is preceded by a "restriction", that is, some court instruction usually in red. See, e.g., [[2024] UKSC 13](https://caselaw.nationalarchives.gov.uk/uksc/2024/13).