### PR TITLE
CLP-10612 <p> elements within <coverPage>

### DIFF
--- a/src/main/ml-modules/root/judgments/xslts/accessible-html.xsl
+++ b/src/main/ml-modules/root/judgments/xslts/accessible-html.xsl
@@ -466,7 +466,7 @@
 	<xsl:sequence select="uk:get-style-or-class-property($p, 'text-align', $context)" />
 </xsl:function>
 
-<xsl:template match="header//p[not(parent::blockContainer)][not(ancestor::authorialNote)]">
+<xsl:template match="header//p[not(parent::blockContainer)][not(ancestor::authorialNote)] | coverPage/p">
 	<xsl:param name="class-context" as="element()" tunnel="yes" />
 	<xsl:choose>
 		<xsl:when test="exists(child::img) and (every $block in preceding-sibling::* satisfies $block/@name = 'restriction')">


### PR DESCRIPTION
Sometimes there is content within the header of the Word document. This get mapped to the \<coverPage\> element in the XML. (Perhaps it's not the best place for this content, but I thought it would be useful to keep it separate from the XML \<header\>, which represents special content at the top of the front page.)

This fix applies the transform's more complex paragraph handling -- which accounts for things like alignment -- to these paragraphs within the \<coverPage\>.