### PR TITLE
Chore: Update docker compose network to have external: true and remov…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.1"
-
 services:
   marklogic:
     container_name: marklogic
@@ -21,3 +19,4 @@ services:
 networks:
   default:
     name: caselaw
+    external: true


### PR DESCRIPTION
…e version

Needed to add external: true to get this running locally, and removing the version will get rid of the warnings we have about that.