### PR TITLE
Add healthcheck in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,11 @@ services:
     volumes:
       - ./.docker/db/data/:/var/opt/MarkLogic/
       - ./.docker/db/backup:/var/opt/backup
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:7997/LATEST/healthcheck"]
+      interval: 2s
+      timeout: 60s
+      retries: 30
 
 networks:
   default:


### PR DESCRIPTION
This allows us to `--wait` for docker compose up to complete in CI before doing the ML deployment, instead of sleeping.