### PR TITLE
Chore: Update populate scripts to add collection and update readme to…

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Ensure that `MARKLOGIC_HOST` in `.env` in the editor and public ui is set to `ho
 
 ### 4. (Optional) Populate data in the local database
 
-To get some example documents onto the local database, there is a `development_scripts/populate.py` that copies documents from the live caselaw site (it doesn't import or fake properties) into it. (Check https://caselaw.nationalarchives.gov.uk/terms-of-use and get in touch if you intend to download many more than these.)
+To get some example documents onto the local database, there are `development_scripts/populate_top_judgments_and_neighbours.py` and `development_scripts/populate_from_caselaw.py` which copy documents from the live caselaw site (they don't import or fake properties) into your local database. (Check https://caselaw.nationalarchives.gov.uk/terms-of-use and get in touch if you intend to download many more than these.)
 
 There are also other ways other importing data as detailed further down the readme but haven't been tested for a while.
 

--- a/development_scripts/populate_from_caselaw.py
+++ b/development_scripts/populate_from_caselaw.py
@@ -32,7 +32,7 @@ for url in urls:
     print("got xml")
 
     response = requests.put(
-        f"http://admin:admin@localhost:8011/LATEST/documents?uri={ml_url}",
+        f"http://admin:admin@localhost:8011/LATEST/documents?uri={ml_url}&collection=judgment",
         data=xml,
     )
     response.raise_for_status()

--- a/development_scripts/populate_top_judgments_and_neighbours.py
+++ b/development_scripts/populate_top_judgments_and_neighbours.py
@@ -43,10 +43,13 @@ def save_judgment_xml(url, xml):
     print("Saving judgment: %s" % url)
     ml_url = f"/{url}.xml"
     response = requests.put(
-        f"http://admin:admin@localhost:8011/LATEST/documents?uri={ml_url}",
+        f"http://admin:admin@localhost:8011/LATEST/documents?uri={ml_url}&collection=judgment",
         data=xml,
     )
-    response.raise_for_status()
+    try:
+        response.raise_for_status()
+    except requests.exceptions.RequestException as e:
+        print("Something went wrong saving the judgment: %s" % e)
 
 
 def get_neighbours_for_judgment(xml):


### PR DESCRIPTION
… reference them

There are 2 populate scripts and the README.md was referencing a script that doesn't exist. I've also added `collection` to the save endpoints to ensure they get a collection added. Finally, I also added a try/except around the save in the `development_scripts/populate_from_caselaw.py` script as it seems it is failing on some (but not all) when saving.