### PR TITLE
[FCL-176] Tooling configuration audit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build
 gradle-*.properties
 !gradle-development.properties
 __pycache__
+node_modules/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,19 @@
-exclude: "^docs/|/migrations/"
-default_install_hook_types: [pre-commit, pre-push]
-
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
-      - id: trailing-whitespace
-      - id: end-of-file-fixer
-      - id: check-yaml
+      - id: check-added-large-files
+      - id: check-case-conflict
+      - id: check-json
+        exclude: src/main/rest-api.json # This is a template file, not actual JSON
+      - id: check-merge-conflict
       - id: check-xml
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: forbid-submodules
+      - id: mixed-line-ending
+      - id: no-commit-to-branch
+      - id: trailing-whitespace
 
   - repo: local
     hooks:
@@ -37,9 +42,3 @@ repos:
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
-
-# sets up .pre-commit-ci.yaml to ensure pre-commit dependencies stay up to date
-ci:
-  autoupdate_schedule: weekly
-  skip: []
-  submodules: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,13 @@ repos:
       - id: no-commit-to-branch
       - id: trailing-whitespace
 
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.5.0
+    hooks:
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format
+
   - repo: local
     hooks:
       - id: validate-schemas
@@ -25,20 +32,8 @@ repos:
         entry: python scripts/validate_schemas
         files: .xsd$
 
-  - repo: https://github.com/psf/black
-    rev: 23.11.0
-    hooks:
-      - id: black
-
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.1.0
     hooks:
       - id: prettier
         types_or: [scss, yaml, markdown, javascript, xml]
-
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    # Ruff version.
-    rev: v0.1.6
-    hooks:
-      - id: ruff
-        args: [--fix, --exit-non-zero-on-fix]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+exclude: src/main/.*\.json # These are templates, not real JSON. They won't parse cleanly.
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0
@@ -5,7 +7,6 @@ repos:
       - id: check-added-large-files
       - id: check-case-conflict
       - id: check-json
-        exclude: src/main/rest-api.json # This is a template file, not actual JSON
       - id: check-merge-conflict
       - id: check-xml
       - id: check-yaml
@@ -33,7 +34,7 @@ repos:
         files: .xsd$
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.1.0
+    rev: v4.0.0-alpha.8
     hooks:
       - id: prettier
-        types_or: [scss, yaml, markdown, javascript, xml]
+        types_or: [yaml, json, xml, markdown, scss, javascript]

--- a/development_scripts/populate_top_judgments_and_neighbours.py
+++ b/development_scripts/populate_top_judgments_and_neighbours.py
@@ -33,14 +33,14 @@ urls = [
 
 
 def get_judgment_xml(url):
-    print("Getting judgment: %s" % url)
+    print(f"Getting judgment: {url}")
     response = requests.get(f"https://caselaw.nationalarchives.gov.uk/{url}/data.xml")
     response.raise_for_status()
     return response.content
 
 
 def save_judgment_xml(url, xml):
-    print("Saving judgment: %s" % url)
+    print(f"Saving judgment: {url}")
     ml_url = f"/{url}.xml"
     response = requests.put(
         f"http://admin:admin@localhost:8011/LATEST/documents?uri={ml_url}&collection=judgment",
@@ -49,7 +49,7 @@ def save_judgment_xml(url, xml):
     try:
         response.raise_for_status()
     except requests.exceptions.RequestException as e:
-        print("Something went wrong saving the judgment: %s" % e)
+        print(f"Something went wrong saving the judgment: {e}")
 
 
 def get_neighbours_for_judgment(xml):
@@ -59,18 +59,12 @@ def get_neighbours_for_judgment(xml):
         "./akn:judgment/akn:meta/akn:identification/akn:FRBRWork/akn:FRBRname",
         ns,
     ).attrib["value"]
-    print("Getting neighbours for judgment title: %s" % title)
-    search_url = (
-        "https://caselaw.nationalarchives.gov.uk/judgments/results?query="
-        + quote(title)
-    )
+    print(f"Getting neighbours for judgment title: {title}")
+    search_url = "https://caselaw.nationalarchives.gov.uk/judgments/results?query=" + quote(title)
     search_results = requests.get(search_url)
     search_soup = BeautifulSoup(search_results.content, "html.parser")
-    neighbours = list(
-        re.sub(r"^\/", "", a["href"])
-        for a in search_soup.select(".judgment-listing__title a")
-    )
-    print("... found %s" % len(neighbours))
+    neighbours = list(re.sub(r"^\/", "", a["href"]) for a in search_soup.select(".judgment-listing__title a"))
+    print(f"... found {len(neighbours)}")
     return neighbours
 
 
@@ -85,6 +79,6 @@ for url in urls:
             save_judgment_xml(url2, xml2)
             found.add(url2)
         else:
-            print("Skipping already imported judgment %s" % url2)
+            print(f"Skipping already imported judgment {url2}")
     print(f"**** {url} and close title matches added to local Marklogic db ****")
-print("DONE. Imported %s judgments." % len(found))
+print(f"DONE. Imported {len(found)} judgments.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,10 @@ pytest = "^7.4.3"
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
-
 [tool.ruff]
+line-length = 120
+
+[tool.ruff.lint]
 ignore = ["E501", "G004", "PLR2004", "RUF005", "RUF012", "UP040"] # long lines, fstrings in logs, magic values, consider not concat, mutable classbits, type instead of TypeAlias
 extend-select = ["W", "B", "Q", "C90", "I", "UP", "YTT", "ASYNC", "S", "BLE", "A", "COM", "C4", "DTZ", "T10", "DJ", "EM", "EXE", "FA",
                  "ISC", "ICN", "G", "INP", "PIE", "T20", "PYI", "PT", "Q", "RSE", "RET", "SLF", "SLOT", "SIM", "TID", "TCH", "INT", "PTH",
@@ -24,8 +26,8 @@ extend-select = ["W", "B", "Q", "C90", "I", "UP", "YTT", "ASYNC", "S", "BLE", "A
 unfixable = ["ERA"]
 
 # things skipped:
-# N: naming, possibly good
-# D: docstrings missing throughout
+# N: naming, possibly good
+# D: docstrings missing throughout
 # ANN: annotations missing throughout
 # FBT: not convinced boolean trap worth auto-banning.
 # CPY: copyright at top of each file
@@ -37,19 +39,10 @@ unfixable = ["ERA"]
 # PD, NPY, AIR: ignored, panda / numpy / airflow specific
 # FURB: not yet out of preview
 
-
-
-[tool.ruff.extend-per-file-ignores]
+[tool.ruff.lint.extend-per-file-ignores]
 "*" = ["RET505", # disagree with if X: return Y else: return Z being wrong
        "T201",   # print
        "S113",   # requests no timeout : TODO
       ]
 "tests/*" = ["S101"]  # assert fine in tests
-"development_scripts/populate_top_judgments_and_neighbours.py" = ["S314", "C400"] # TODO
-
-
-
-[tool.ruff.isort]
-known-first-party = ["ds-caselaw-editor-ui", "config"]
-
-[tool.ruff.pycodestyle]
+"development_scripts/populate_top_judgments_and_neighbours.py" = ["S314", "C400"] # TODO


### PR DESCRIPTION
A series of commits which together make all of FCL's repositories behave more consistently with regard to tooling.

## Jira

FCL-176

## What?

- [x] `.pre-commit-config.yaml` does not exclude directories which don't exist, doesn't set default hooks where they aren't needed, and doesn't specify auto-update behaviour
- [x] The `pre-commit-hooks` repo includes the new, broader set of recommended checks
- [x] Python formatting is done using [ruff](https://docs.astral.sh/ruff/)
- [x] Python linting is done using [ruff](https://docs.astral.sh/ruff/)
- [x] `detect-secrets` is removed (deprecated in favour of GitHub's more comprehensive approach)
- [x] prettier config has been harmonised