### PR TITLE
CLP-11811 copy cell properties from table styles

### DIFF
--- a/src/main/ml-modules/root/judgments/xslts/accessible-html.xsl
+++ b/src/main/ml-modules/root/judgments/xslts/accessible-html.xsl
@@ -334,7 +334,7 @@
 <!-- returns a sequence of key/value pairs, each divided by a colon -->
 <xsl:function name="uk:get-all-class-properties" as="xs:string*">
 	<xsl:param name="context" as="element()" />
-	<xsl:param name="selector" as="xs:string" /> <!-- constructed with helper function below -->
+	<xsl:param name="selector" as="xs:string" /> <!-- constructed with 'augment-simple-class-selector' function below -->
 	<xsl:variable name="key" select="concat(generate-id($context), '|', $selector)" />
 	<xsl:for-each select="key('classes', $key, $all-classes-parsed)/uk:property">
 		<xsl:sequence select="concat(@key, ':', @value)" />
@@ -344,7 +344,7 @@
 <!-- returns a sequence of key/value pairs, each divided by a colon -->
 <xsl:function name="uk:get-inline-class-properties-1" as="xs:string*">
 	<xsl:param name="context" as="element()" />
-	<xsl:param name="selector" as="xs:string" /> <!-- constructed with helper function below -->
+	<xsl:param name="selector" as="xs:string" /> <!-- constructed with 'make-class-selector' function below -->
 	<xsl:variable name="key" select="concat(generate-id($context), '|', $selector)" />
 	<xsl:for-each select="key('classes', $key, $all-classes-parsed)/uk:property">
 		<xsl:if test="string(@key) = $inline-properties">


### PR DESCRIPTION
Sometimes there is cell formatting associated with a _table_ style. In the XML, we might see CSS in the `<presentation>` block that looks like this:
```CSS
.TableGrid td { border: 0.5pt solid; }
```
and then some XML in the body that looks like this:
```XML
<table class="TableGrid">
   <tr>
      <td>...</td>
   </tr>
</table>
```
With the included fix, these cell properties will be copied into the style attribute of the HTML <td> like this:
```HTML
<table>
   <tr>
      <td style="border: 0.5pt solid">...</td>
   </tr>
</table>
```
We already do something similar with inline styling contained in a paragraph style. This fix just extends it to table styles.
This fix is needed for [2024] UKFTT 564 (TC). See Jira issue CLP-11811
