### PR TITLE
[FCL-298] Hide # links from enrichment

### DIFF
--- a/src/main/ml-modules/root/judgments/xslts/accessible-html.xsl
+++ b/src/main/ml-modules/root/judgments/xslts/accessible-html.xsl
@@ -18,6 +18,9 @@
 <xsl:function name="uk:link-is-supported" as="xs:boolean">
 	<xsl:param name="href" as="attribute()?" />
 	<xsl:choose>
+		<xsl:when test="$href='#'">
+			<xsl:sequence select="false()" />
+		</xsl:when>
 		<xsl:when test="starts-with($href, '#')">
 			<xsl:sequence select="true()" />
 		</xsl:when>


### PR DESCRIPTION
Enrichment generates links with '#' as the URL for documents which it can't give a URL for. This isn't ideal, but we should ignore those links.

https://staging.caselaw.nationalarchives.gov.uk/ewca/civ/2003/5471

the [1990] 2 AC 1 link no longer appears in the HTML output.

<img width="706" alt="image" src="https://github.com/user-attachments/assets/32909117-24ea-4f8d-bf38-82c5cb7bee06">

https://national-archives.atlassian.net/jira/software/projects/FCL/boards/136?selectedIssue=FCL-298