### PR TITLE
Set request timeout to 10 seconds. 

### DIFF
--- a/src/main/ml-config/servers/rest-api-server.json
+++ b/src/main/ml-config/servers/rest-api-server.json
@@ -1,4 +1,5 @@
 {
   "server-name": "%%NAME%%",
-  "authentication": "basic"
+  "authentication": "basic",
+  "request-timeout": 10
 }


### PR DESCRIPTION
Docs:
http://docs.marklogic.com/REST/POST/manage/v2/servers
under `request-timeout`. See also: `default-time-limit`, `session-timeout`, `keep-alive-timeout`