### PR TITLE
[FCL-384] Set `default-time-limit` to 10 seconds.

### DIFF
--- a/src/main/ml-config/servers/rest-api-server.json
+++ b/src/main/ml-config/servers/rest-api-server.json
@@ -1,4 +1,5 @@
 {
   "server-name": "%%NAME%%",
-  "authentication": "basic"
+  "authentication": "basic",
+  "default-time-limit": 10
 }


### PR DESCRIPTION
See: https://github.com/marklogic/ml-gradle/tree/master/examples/sample-project/src/main/ml-config/servers for the gradle documentation and http://docs.marklogic.com/REST/POST/manage/v2/servers for other timeout related options

## Jira

FCL-384