### PR TITLE
Use corb2 to set identifiers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ gradle-*.properties
 !gradle-development.properties
 __pycache__
 node_modules/
+corb2/*.jar
+corb2/*.log

--- a/corb2/README.md
+++ b/corb2/README.md
@@ -1,0 +1,7 @@
+`brew install temurin` to get a working Java (I had to install-uninstall-install)
+
+Download corb2 from https://github.com/marklogic-community/corb2/releases
+Download xcc from https://repo1.maven.org/maven2/com/marklogic/marklogic-xcc/11.1.0/ or https://developer.marklogic.com/products/xcc-2/ (I used maven)
+(both into this directory)
+
+`corb migrate-ncn` will run the code, `migrate-ncn.log` will show what it writes to the identifiers

--- a/corb2/corb
+++ b/corb2/corb
@@ -1,0 +1,1 @@
+java -server -cp .:marklogic-xcc-11.1.0.jar:marklogic-corb-2.5.6.jar -DOPTIONS-FILE=$1.properties com.marklogic.developer.corb.Manager xcc://admin:admin@localhost:8011

--- a/corb2/get-uris.xqy
+++ b/corb2/get-uris.xqy
@@ -1,0 +1,4 @@
+let $uris := cts:uris("",(),cts:collection-query(
+   ("http://marklogic.com/collections/dls/latest-version")
+))
+return (count($uris), $uris)

--- a/corb2/migrate-ncn.properties
+++ b/corb2/migrate-ncn.properties
@@ -1,0 +1,9 @@
+MODULES-DATABASE=caselaw-modules
+INSTALL = 1
+
+URIS-MODULE=get-uris.xqy
+PROCESS-MODULE=migrate-ncn.xqy
+
+PROCESS-TASK=com.marklogic.developer.corb.ExportBatchToFileTask
+EXPORT-FILE-NAME=migrate-ncn.log
+THREAD-COUNT=10

--- a/corb2/migrate-ncn.xqy
+++ b/corb2/migrate-ncn.xqy
@@ -1,0 +1,34 @@
+declare namespace uk = "https://caselaw.nationalarchives.gov.uk/akn";
+
+import module namespace sem = "http://marklogic.com/semantics"
+      at "/MarkLogic/semantics.xqy";
+
+(: This is intended to be a migration script that runs once;
+   it should not be run on a database which already has identifiers :)
+
+declare variable $URI external;
+
+let $cite := fn:doc($URI)//uk:cite/text()
+let $slug := fn:replace(
+                fn:replace($URI, "\.xml$", "")
+                , "^/", "")
+let $log := ("")
+let $uuid := "id-"||sem:uuid-string()
+let $log := ($log, "Processing", $URI, $cite, $uuid)
+let $node :=
+<identifiers><identifier>
+<namespace>ukncn</namespace>
+<uuid>{$uuid}</uuid>
+<value>{$cite}</value>
+<url_slug>{$slug}</url_slug>
+</identifier></identifiers>
+let $log := ($log, xdmp:quote($node))
+
+let $log := ($log, if
+            (fn:starts-with($URI, "/failures/") or fn:starts-with($URI, "/collisions/"))
+          then
+            "ignored as failure/collision"
+          else
+            "set property" || xdmp:document-set-property($URI, $node))
+
+return string-join($log, "&#10;")


### PR DESCRIPTION
A working corb2 setup, being used to add NCN identifiers to existing documents.

⚠️ The NCN identifier code expects documents to be at NCN-based URIs, which we are moving away from. ⚠️ 
⚠️ This code should not be run on a database which has identifiers you care about ⚠️ 