### PR TITLE
Add identifier_value to compiled_url_slugs table

### DIFF
--- a/src/main/ml-schemas/tde/sql-document-uri-slugs-extract.xml
+++ b/src/main/ml-schemas/tde/sql-document-uri-slugs-extract.xml
@@ -41,6 +41,14 @@
 	  <invalid-values>reject</invalid-values>
 	  <reindexing>visible</reindexing>
 	</column>
+	<column>
+	  <name>identifier_value</name>
+	  <scalar-type>string</scalar-type>
+	  <val>value</val>
+	  <nullable>false</nullable>
+	  <invalid-values>reject</invalid-values>
+	  <reindexing>visible</reindexing>
+	</column>
       </columns>
     </row>
   </rows>


### PR DESCRIPTION
Part of https://national-archives.atlassian.net/browse/FCL-582

In order to keep all the identifier objects together in one place, I'm adding the value of the identifier to the lookup table
![image](https://github.com/user-attachments/assets/2f99f136-c983-46b9-bef5-12b23f30b537)

We encountered strange errors when trying to deploy this to staging
```> Error occurred while loading REST modules: Error occurred while loading modules; host: ml.external.staging.caselaw.nationalarchives.gov.uk; port: 8011; cause: Local message: config/resources write failed: Internal Server Error. Server Message: XDMP-EXTIME: Time limit exceeded```

But they seemed to be transient...