### PR TITLE
Fix Space-assignment syntax in Groovy DSL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,8 +14,7 @@ plugins {
 
 repositories {
   mavenCentral()
-  // jcenter() // Removed in Gradle 8
-  maven {url "https://developer.marklogic.com/maven2/"}
+  maven {url = "https://developer.marklogic.com/maven2/"}
 }
 
 configurations {


### PR DESCRIPTION
From the problems report:

Space-assignment syntax in Groovy DSL has been deprecated.
This is scheduled to be removed in Gradle 10.0
Solutions: Use assignment ('url = <value>') instead.

The other problems in the problem report appear to be within MarkLogic so not fixing them just yet.
