### PR TITLE
Add namespace to identifier table

### DIFF
--- a/src/main/ml-schemas/tde/sql-document-uri-slugs-extract.xml
+++ b/src/main/ml-schemas/tde/sql-document-uri-slugs-extract.xml
@@ -49,6 +49,14 @@
 	  <invalid-values>reject</invalid-values>
 	  <reindexing>visible</reindexing>
 	</column>
+	<column>
+	  <name>identifier_namespace</name>
+	  <scalar-type>string</scalar-type>
+	  <val>namespace</val>
+	  <nullable>false</nullable>
+	  <invalid-values>reject</invalid-values>
+	  <reindexing>visible</reindexing>
+	</column>
       </columns>
     </row>
   </rows>


### PR DESCRIPTION
In order to fully identify an identifier we'll need the namespace too.