### PR TITLE
Add uk:party to party search

### DIFF
--- a/src/main/ml-modules/root/judgments/search/search-v2.xqy
+++ b/src/main/ml-modules/root/judgments/search/search-v2.xqy
@@ -62,7 +62,8 @@ let $query1 := if ($q and not(helper:is-a-consignment-number($q))) then (helper:
 let $query2 := if ($party) then
     cts:or-query((
         cts:element-word-query(fn:QName('http://docs.oasis-open.org/legaldocml/ns/akn/3.0', 'party'), $party),
-        cts:element-attribute-word-query(fn:QName('http://docs.oasis-open.org/legaldocml/ns/akn/3.0', 'FRBRname'), fn:QName('', 'value'), $party)
+        cts:element-attribute-word-query(fn:QName('http://docs.oasis-open.org/legaldocml/ns/akn/3.0', 'FRBRname'), fn:QName('', 'value'), $party),
+        cts:element-word-query(fn:QName('https://caselaw.nationalarchives.gov.uk/akn', 'party'), $party)
     ))
 else ()
 


### PR DESCRIPTION
To support searching on parties which are not present within the full text of a judgment due to coming from an external metadata source, we should add uk:party to our list of party fields.