### PR TITLE
Include identifiers in search results

### DIFF
--- a/src/main/ml-modules/root/judgments/search/helper.xqy
+++ b/src/main/ml-modules/root/judgments/search/helper.xqy
@@ -334,7 +334,7 @@ declare function add-property-to-search($search-results, $property-name) {
                 </xsl:copy>
                 <!-- Add new node -->
                 <xsl:variable name="uri" select="ancestor::search:result/@uri"/>
-                <search:extracted kind="property"><xsl:copy-of select="map:get($identifier-map, $uri)"/></search:extracted>
+                <search:extracted kind="{{$property-name}}"><xsl:copy-of select="map:get($identifier-map, $uri)"/></search:extracted>
             </xsl:template>
         </xsl:stylesheet>
 

--- a/src/main/ml-modules/root/judgments/search/helper.xqy
+++ b/src/main/ml-modules/root/judgments/search/helper.xqy
@@ -9,6 +9,7 @@ import module namespace json = "http://marklogic.com/xdmp/json"
 
 declare namespace akn = "http://docs.oasis-open.org/legaldocml/ns/akn/3.0";
 declare namespace uk = "https://caselaw.nationalarchives.gov.uk";
+declare namespace search = "http://marklogic.com/appservices/search";
 
 declare variable $default-options as xs:string* := ( 'case-insensitive' );
 
@@ -306,3 +307,37 @@ declare private variable $snippet-filter := <xsl:stylesheet xmlns:xsl="http://ww
         </xsl:copy>
     </xsl:template>
 </xsl:stylesheet>;
+
+declare function add-property-to-search($search-results, $property-name) {
+    let $result-uri := $search-results//search:result/@uri
+    let $identifiers := xdmp:document-get-properties($result-uri, xs:QName($property-name))
+    let $identifier-map := map:map()
+    let $_ := for $uri in $result-uri return map:put($identifier-map, $uri, xdmp:document-get-properties($uri, xs:QName("identifiers")))
+    let $params := map:new(
+        map:entry(xdmp:key-from-QName(fn:QName("", "identifier-map")), $identifier-map)
+    )
+    let $merge-properties :=
+        <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+            xmlns:search="http://marklogic.com/appservices/search"
+            xmlns:map="http://marklogic.com/xdmp/map">
+            <xsl:param name="identifier-map"/>
+            <xsl:template match="/ | @* | node()">
+                <xsl:copy>
+                    <xsl:apply-templates select="@* | node()" />
+                </xsl:copy>
+            </xsl:template>
+            <xsl:template match="search:extracted">
+                <!-- Copy the element -->
+                <xsl:copy>
+                    <!-- And everything inside it -->
+                    <xsl:apply-templates select="@* | node()"/>
+                </xsl:copy>
+                <!-- Add new node -->
+                <xsl:variable name="uri" select="ancestor::search:result/@uri"/>
+                <search:extracted kind="property"><xsl:copy-of select="map:get($identifier-map, $uri)"/></search:extracted>
+            </xsl:template>
+        </xsl:stylesheet>
+
+
+    return xdmp:xslt-eval($merge-properties, $search-results, $params)
+    };

--- a/src/main/ml-modules/root/judgments/search/search-v2.xqy
+++ b/src/main/ml-modules/root/judgments/search/search-v2.xqy
@@ -198,8 +198,5 @@ let $search-options := <options xmlns="http://marklogic.com/appservices/search">
 let $boosted-query := helper:boost-title-and-ncn($q, $query)
 
 let $results := search:resolve(element x { $boosted-query }/*, $search-options, $start, $page-size)
-let $total as xs:integer := xs:integer($results/@total)
-let $pages as xs:integer := if ($total mod $page-size eq 0) then $total idiv $page-size else $total idiv $page-size + 1
-let $params := $params => map:with('pages', $pages)
 
-return $results
+return helper:add-property-to-search($results, "identifiers")


### PR DESCRIPTION
In order for search to provide the public URL of a judgment, the PUI needs to have access to the identifiers either via the search results or by asking for them with a second call. The first should be a better solution.

This isn't how MarkLogic recommends we do this -- but I can't make head or tails of their [documentation](https://docs.marklogic.com/guide/rest-dev/transforms). Instead we use XSLT to inject the new tags.

Implements properly what we tried to do in https://github.com/nationalarchives/ds-caselaw-marklogic/pull/24 -- we could after this refactor to add other properties to the search results and change how the editor works, but that doesn't feel like something we strongly need.