### PR TITLE
Add properties metadata for one file; we can change how the others behave later

### DIFF
--- a/development_scripts/fixtures/eat-2023-1-content.xml
+++ b/development_scripts/fixtures/eat-2023-1-content.xml
@@ -1,0 +1,2049 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"
+    xmlns:html="http://www.w3.org/1999/xhtml"
+    xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
+    <judgment name="judgment">
+        <meta>
+            <identification source="#tna">
+                <FRBRWork>
+                    <FRBRthis value="https://caselaw.nationalarchives.gov.uk/id/eat/2023/1"/>
+                    <FRBRuri value="https://caselaw.nationalarchives.gov.uk/id/eat/2023/1"/>
+                    <FRBRdate date="2023-01-24" name="judgment"/>
+                    <FRBRauthor href="#eat"/>
+                    <FRBRcountry value="GB-UKM"/>
+                    <FRBRnumber value="1"/>
+                    <FRBRname value="IMPERIAL COLLEGE HEALTHCARE NHS TRUST v MR N MATAR"/>
+                </FRBRWork>
+                <FRBRExpression>
+                    <FRBRthis value="https://caselaw.nationalarchives.gov.uk/eat/2023/1"/>
+                    <FRBRuri value="https://caselaw.nationalarchives.gov.uk/eat/2023/1"/>
+                    <FRBRdate date="2023-01-24" name="judgment"/>
+                    <FRBRauthor href="#eat"/>
+                    <FRBRlanguage language="eng"/>
+                </FRBRExpression>
+                <FRBRManifestation>
+                    <FRBRthis value="https://caselaw.nationalarchives.gov.uk/eat/2023/1/data.xml"/>
+                    <FRBRuri value="https://caselaw.nationalarchives.gov.uk/eat/2023/1/data.xml"/>
+                    <FRBRdate date="2023-01-25T12:19:32" name="transform"/>
+                    <FRBRdate date="2023-01-27T11:05:09" name="tna-enriched"/>
+                    <FRBRauthor href="#tna"/>
+                    <FRBRformat value="application/xml"/>
+                </FRBRManifestation>
+            </identification>
+            <lifecycle source="#">
+                <eventRef date="2023-01-24" refersTo="#judgment" source="#"/>
+            </lifecycle>
+            <references source="#tna">
+                <TLCOrganization eId="eat" href="https://www.gov.uk/courts-tribunals/employment-appeal-tribunal" showAs="Employment Appeal Tribunal"/>
+                <TLCOrganization eId="tna" href="https://www.nationalarchives.gov.uk/" showAs="The National Archives"/>
+                <TLCEvent eId="judgment" href="#" showAs="judgment"/>
+                <TLCPerson eId="imperial-college-healthcare-nhs-trust" href="" showAs="IMPERIAL COLLEGE HEALTHCARE NHS TRUST"/>
+                <TLCPerson eId="mr-p-ziprin" href="" showAs="MR P ZIPRIN"/>
+                <TLCPerson eId="mr-n-matar" href="" showAs="MR N MATAR"/>
+                <TLCRole eId="appellant" href="" showAs="Appellant"/>
+                <TLCRole eId="respondent" href="" showAs="Respondent"/>
+            </references>
+            <proprietary source="#">
+                <uk:court>EAT</uk:court>
+                <uk:year>2023</uk:year>
+                <uk:number>1</uk:number>
+                <uk:cite>[2023] EAT 1</uk:cite>
+                <uk:parser>0.12.3</uk:parser>
+                <uk:hash>a02bd991895cc802461cea138ef238781d69016fdb2d141e3504da715449ca21</uk:hash>
+                <uk:tna-enrichment-engine>0.1.0</uk:tna-enrichment-engine>
+            </proprietary>
+            <presentation source="#">
+                <html:style>
+#judgment { font-size: 11pt; font-family: 'Times New Roman'; }
+#judgment .Heading2 { font-size: 13pt; color: #365F91; }
+#judgment .Heading3 { font-weight: bold; font-family: 'Times New Roman'; font-size: 13.5pt; }
+#judgment .BodyText { margin-left: 0.35in; font-family: Algerian; font-size: 12pt; }
+#judgment .ListParagraph { }
+#judgment .TableParagraph { }
+#judgment .Header { }
+#judgment .Footer { }
+#judgment .CommentText { font-size: 10pt; }
+#judgment .CommentSubject { font-weight: bold; font-size: 10pt; }
+#judgment .NormalWeb { font-family: 'Times New Roman'; font-size: 12pt; }
+#judgment .legclearfix { font-family: 'Times New Roman'; font-size: 12pt; }
+#judgment .edpnum { font-family: 'Times New Roman'; font-size: 12pt; }
+#judgment .Hyperlink { text-decoration-line: underline; text-decoration-style: solid; color: #0000FF; }
+#judgment .UnresolvedMention { color: #605E5C; background-color: initial; }
+#judgment .HeaderChar { }
+#judgment .FooterChar { }
+#judgment .CommentReference { font-size: 8pt; }
+#judgment .CommentTextChar { font-size: 10pt; }
+#judgment .CommentSubjectChar { font-weight: bold; font-size: 10pt; }
+#judgment .legds { }
+#judgment .legchangedelimiter { }
+#judgment .legsubstitution { }
+#judgment .pnum { }
+#judgment .Emphasis { font-style: italic; }
+#judgment .Heading3Char { font-weight: bold; font-family: 'Times New Roman'; font-size: 13.5pt; }
+#judgment .Strong { font-weight: bold; }
+#judgment .label { }
+#judgment .Heading2Char { font-size: 13pt; color: #365F91; }
+#judgment .TableGrid { }
+#judgment .TableGrid td { border: 0.5pt solid; }
+                </html:style>
+            </presentation>
+        </meta>
+        <coverPage>
+            <p>
+                <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-family:'Times New Roman';font-size:8pt;color:#000000">Judgment approved by the court for handing down</span>
+                <span style="font-weight:bold;font-family:'Times New Roman';font-size:8pt;color:#000000">:</span>
+                <span style="font-family:'Times New Roman';font-size:10pt;color:#010302"></span>
+                <marker name="tab"/>
+                <marker name="tab"/>
+                <span style="font-family:'Times New Roman';font-size:6pt">                        IMPERIAL COLLEGE HEALTHCARE NHS TRUST AND ANOR v MATAR</span>
+            </p>
+        </coverPage>
+        <header>
+            <p>
+                <span style="text-decoration-line:underline;text-decoration-style:solid;font-family:'Times New Roman';font-size:12pt;color:#000000">Neutral Citation Number: </span>
+                <neutralCitation style="text-decoration-line:underline;text-decoration-style:solid;font-family:'Times New Roman';font-size:12pt;color:#000000">[2023] EAT 1</neutralCitation>
+            </p>
+            <p style="text-align:right">
+                <span style="text-decoration-line:underline;text-decoration-style:solid;font-family:'Times New Roman';font-size:12pt;color:#000000">Case No: </span>
+                <docketNumber style="text-decoration-line:underline;text-decoration-style:solid;font-family:'Times New Roman';font-size:12pt;color:#000000">EA-2021-000770-OO</docketNumber>
+                <span style="text-decoration-line:underline;text-decoration-style:solid;font-family:'Times New Roman';font-size:12pt;color:#000000"> and </span>
+                <docketNumber style="text-decoration-line:underline;text-decoration-style:solid;font-family:'Times New Roman';font-size:12pt;color:#000000">EA-2022-000069-OO</docketNumber>
+            </p>
+            <p>
+                <courtType refersTo="#eat" style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-family:'Times New Roman';font-size:12pt;color:#000000">EMPLOYMENT APPEAL TRIBUNAL</courtType>
+            </p>
+            <p style="text-align:right">
+                <span style="text-decoration-line:underline;text-decoration-style:solid;font-family:'Times New Roman';font-size:12pt;color:#000000">Rolls Building</span>
+            </p>
+            <p style="text-align:right">
+                <span style="text-decoration-line:underline;text-decoration-style:solid;font-family:'Times New Roman';font-size:12pt;color:#000000">Fetter Lane, London, EC4A 1NL</span>
+            </p>
+            <p style="text-align:right">
+                <span style="text-decoration-line:underline;text-decoration-style:solid;font-family:'Times New Roman';font-size:12pt;color:#000000">Date: </span>
+                <docDate date="2023-01-24" refersTo="#judgment" style="text-decoration-line:underline;text-decoration-style:solid;font-family:'Times New Roman';font-size:12pt;color:#000000">24 January 2023</docDate>
+            </p>
+            <p style="text-align:center">
+                <span style="font-weight:bold;font-family:'Times New Roman';font-size:12pt;color:#000000">Before</span>
+                <span style="font-family:'Times New Roman';font-size:12pt;color:#000000"> :</span>
+            </p>
+            <p style="text-align:center">
+                <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-family:'Times New Roman';font-size:12pt;color:#000000">THE HONOURABLE MRS JUSTICE EADY DBE, PRESIDENT</span>
+            </p>
+            <p style="text-align:center">
+                <span style="font-family:'Times New Roman';font-size:12pt;color:#000000">- - - - - - - - - - - - - - - - - - - - -</span>
+            </p>
+            <p style="text-align:center">
+                <span style="font-weight:bold;font-family:'Times New Roman';font-size:12pt;color:#000000">Between :</span>
+            </p>
+            <p>
+                <marker name="tab"/>
+                <party as="#appellant" refersTo="#imperial-college-healthcare-nhs-trust">
+                    <span style="font-weight:bold;font-size:12pt">IMPERIAL COLLEGE HEALTHCARE NHS TRUST (1)</span>
+                </party>
+            </p>
+            <p style="text-align:center">
+                <party as="#appellant" refersTo="#mr-p-ziprin" style="font-weight:bold;font-size:12pt">MR P ZIPRIN (2)</party>
+            </p>
+            <p style="text-align:right">
+                <role refersTo="#appellant">
+                    <marker name="tab"/>
+                    <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt">Appellants</span>
+                </role>
+            </p>
+            <p style="text-align:center">
+                <span style="font-weight:bold;font-size:12pt">- v –</span>
+            </p>
+            <p>
+                <marker name="tab"/>
+                <party as="#respondent" refersTo="#mr-n-matar">
+                    <span style="font-weight:bold;font-size:12pt">MR N MATAR</span>
+                </party>
+            </p>
+            <p style="text-align:right">
+                <role refersTo="#respondent" style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt">Respondent</role>
+            </p>
+            <p style="text-align:center">
+                <span style="font-family:'Times New Roman';font-size:12pt;color:#000000">- - - - - - - - - - - - - - - - - - - - -</span>
+            </p>
+            <p style="text-align:center">
+                <span style="font-family:'Times New Roman';font-size:12pt;color:#000000">- - - - - - - - - - - - - - - - - - - - -</span>
+            </p>
+            <p style="text-align:center;text-indent:-0in">
+                <span style="font-weight:bold;font-family:'Times New Roman';font-size:12pt;color:#000000">Spencer Keen </span>
+                <span style="font-family:'Times New Roman';font-size:12pt;color:#000000">(instructed</span>
+                <span style="font-weight:bold;font-family:'Times New Roman';font-size:12pt;color:#000000"></span>
+                <span style="font-family:'Times New Roman';font-size:12pt;color:#000000">by Capsticks Solicitors LLP</span>
+                <span style="font-weight:bold;font-family:'Times New Roman';font-size:12pt;color:#000000">) </span>
+                <span style="font-family:'Times New Roman';font-size:12pt;color:#000000">for the </span>
+                <span style="font-weight:bold;font-family:'Times New Roman';font-size:12pt;color:#000000">Appellants</span>
+            </p>
+            <p style="text-align:center;text-indent:-0in">
+                <span style="font-weight:bold;font-family:'Times New Roman';font-size:12pt;color:#000000">Deshpal Panesar KC (</span>
+                <span style="font-family:'Times New Roman';font-size:12pt;color:#000000">instructed by Charles Russell Speechlys LLP)</span>
+                <span style="font-weight:bold;font-family:'Times New Roman';font-size:12pt;color:#000000"></span>
+                <span style="font-family:'Times New Roman';font-size:12pt;color:#000000">for the </span>
+                <span style="font-weight:bold;font-family:'Times New Roman';font-size:12pt;color:#000000">Respondent</span>
+            </p>
+            <p style="text-align:center">
+                <span style="font-family:'Times New Roman';font-size:12pt;color:#000000">Hearing dates: 6-7 December 2022</span>
+            </p>
+            <p style="text-align:center">
+                <span style="font-family:'Times New Roman';font-size:12pt;color:#000000">- - - - - - - - - - - - - - - - - - - - -</span>
+            </p>
+            <p style="text-align:center">
+                <span style="font-weight:bold;font-family:'Times New Roman';font-size:18pt;color:#000000">JUDGMENT</span>
+            </p>
+            <p style="text-align:center">
+                <span style="font-weight:bold;font-family:'Times New Roman';font-size:12pt;color:#000000">This judgment was handed down by the Judge remotely by circulation to the parties' representatives by email and release to The National Archives. </span>
+            </p>
+            <p style="text-align:center">
+                <span style="font-weight:bold;font-family:'Times New Roman';font-size:12pt;color:#000000">The date and time for hand-down is deemed to be 10:30 am on 24 January 2023</span>
+            </p>
+            <p style="text-align:justify">
+                <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-family:'Times New Roman';font-size:12pt;color:#000000">SUMMARY</span>
+            </p>
+            <p style="text-align:justify">
+                <span style="font-style:italic;font-family:'Times New Roman';font-size:12pt;color:#000000">Age discrimination – less favourable treatment because of age – section 13 Equality Act 2010</span>
+            </p>
+            <p style="text-align:justify">
+                <span style="font-style:italic;font-family:'Times New Roman';font-size:12pt;color:#000000">Age discrimination – remedy – NHS Appointment of Consultants Regulations 1996</span>
+            </p>
+            <p style="text-align:justify">
+                <span style="font-family:'Times New Roman';font-size:12pt;color:#000000">In 2017, the claimant was in his late 50s and intended to retire when he reached 60, in May 2019.  He had been employed by the first respondent as a Locum Consultant for a number of years when it was realised that this was in breach of the </span>
+                <span style="font-weight:bold;font-family:'Times New Roman';font-size:12pt;color:#000000">NHS Appointment of Consultants Regulations 1996</span>
+                <span style="font-family:'Times New Roman';font-size:12pt;color:#000000"> because the claimant was not on the specialist register.  At the time, an investigation was being undertaken into clinical concerns relating to the claimant and his practice was restricted; in the circumstances, the decision was taken not to raise the regulatory matter with him, although the issue was taken up with other (younger) Locum Consultants in the same position and, unlike others, the respondents proactively investigated early retirement costs for the claimant.  </span>
+            </p>
+            <p style="text-align:justify">
+                <span style="font-family:'Times New Roman';font-size:12pt;color:#000000">The investigation was completed by the end of 2017; it did not criticise the claimant’s clinical competence, and there was no longer a need to restrict the claimant’s practice.  When then raising the regulatory issue with the claimant, however, the ET found the respondents failed to provide the same support and encouragement to seek specialist registration as it had for others, in particular another younger Locum Consultant working in the same division.  The respondents explained that they had treated the claimant in the way that they had because they did not consider he would accept a lower status position and because he was close to his intended retirement; the ET found that these were age-related assumptions.  Having not been able to return to work at the same level and with the same autonomy, the claimant resigned in May 2018.  The ET concluded that the claimant had established a prima facie case of age discrimination and found that the respondents had failed to provide a cogent explanation that was in </span>
+                <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">no sense whatsoever because of the claimant’s</span>
+                <span style="font-family:'Times New Roman';font-size:12pt;color:#000000"> age.  It upheld the claimant’s claims of constructive unfair and wrongful dismissal and of direct age discrimination. </span>
+            </p>
+            <p style="text-align:justify">
+                <span style="font-family:'Times New Roman';font-size:12pt;color:#000000">At the subsequent remedy hearing, the ET found that, had the claimant not suffered unlawful discrimination, he would not have sought specialist registration and would not have accepted a lower status position.  It held, however, that he would have accepted an offer that the first respondent had intended to make, and worked out his Locum Consultant contract pursuant to an extended notice period until his retirement in May 2019.  This arrangement would have been ultra vires pursuant to the </span>
+                <span style="font-weight:bold;font-family:'Times New Roman';font-size:12pt;color:#000000">1996 Regulations</span>
+                <span style="font-family:'Times New Roman';font-size:12pt;color:#000000"> but the ET found that the first respondent considered that it was lawful and the parties’ employment relationship would in fact have continued.  In the circumstances, it made an award of compensation for past pecuniary losses, based on that counterfactual scenario, from May 2018 until May 2019. </span>
+            </p>
+            <p style="text-align:justify">
+                <span style="font-family:'Times New Roman';font-size:12pt;color:#000000">The respondents appealed both decisions. </span>
+            </p>
+            <p style="text-align:justify">
+                <span style="font-style:italic;font-family:'Times New Roman';font-size:12pt;color:#000000">Held:</span>
+                <span style="font-family:'Times New Roman';font-size:12pt;color:#000000"> Dismissing both appeals</span>
+            </p>
+            <p style="text-align:justify">
+                <span style="font-family:'Times New Roman';font-size:12pt;color:#000000">In relation to liability, although the ET had erred in failing to have regard to the respondents’ reasons (accepted by the ET in its findings of fact) for their different treatment of the claimant up to December 2017, it had permissibly seen the claimant’s circumstances as materially the same as his named comparator thereafter.  As for the respondents’ objection that it had been perverse for the ET to find that early retirement had not been considered for other (younger) Locum Consultants, the evidence at trial was not such that it could properly be said that the ET reached a conclusion that had not been open to it on the material adduced (or not adduced) below.  The ET had properly applied the burden of proof and, given its primary findings of fact, had been entitled to conclude that the claimant had made out a prima facie case of age discrimination such that it was for the respondents to produce cogent evidence to explain their reasons for his less favourable treatment and to demonstrate that it was in no sense whatsoever because of age.  It was, furthermore, apparent that the ET had been satisfied that the reason for the less favourable treatment of the claimant was because of age.  The ET had not treated this as a </span>
+                <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-family:'Times New Roman';font-size:12pt;color:#000000">James v Eastleigh Borough Council</span>
+                <span style="font-family:'Times New Roman';font-size:12pt;color:#000000"> type of case but had permissibly found that the respondents had made assumptions about the claimant’s response to the regulatory issue that were related to his age. </span>
+            </p>
+            <p style="text-align:justify">
+                <span style="font-family:'Times New Roman';font-size:12pt;color:#000000">As for the remedy appeal, the ET had found that, had he not suffered unlawful discrimination, the claimant would have continued in a lawful employment relationship with the first respondent until May 2019, providing Locum Consultant services pursuant to an agreement that would have been unlawful pursuant to the 1996 Regulations.  Given the need to put the claimant in the position he would have been in had the wrong not occurred, the award of damages for these past pecuniary losses recognised what the ET had found would have been the reality of this counterfactual situation (and see </span>
+                <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-family:'Times New Roman';font-size:12pt;color:#000000">Eastbourne Borough Council v Foster</span>
+                <span style="font-family:'Times New Roman';font-size:12pt;color:#000000"> [2002] ICR 234 CA).  Moreover, on the facts of this case, the result did not offend against public policy, in particular given that the ET had found that the first respondent would have offered this arrangement to the claimant believing that it was lawful.  </span>
+            </p>
+            <p style="text-align:justify">
+                <br/>
+                <span style="font-weight:bold;font-family:'Times New Roman';font-size:12pt;color:#000000">The Honourable Mrs Justice Eady DBE, President:</span>
+            </p>
+            <p style="text-align:justify;margin-right:3.7in">
+                <span style="font-weight:bold;font-family:'Times New Roman';font-size:12pt;color:#000000">Introduction</span>
+            </p>
+        </header>
+        <judgmentBody>
+            <decision>
+                <paragraph eId="para_1">
+                    <num style="font-family:'Times New Roman';font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">1.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#000000">These appeals are brought against two judgments of the Employment Tribunal (“ET”).  The first relates to the ET’s liability judgment and its conclusions on the questions of less favourable treatment and causation for the purposes of section 13 </span>
+                            <span style="font-weight:bold;font-family:'Times New Roman';font-size:12pt;color:#000000">
+                                <ref href="http://www.legislation.gov.uk/id/ukpga/2010/15" uk:canonical="2010 c. 15" uk:origin="TNA" uk:type="legislation">Equality Act 2010</ref>
+                            </span>
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#000000"> (“the EqA”).  The second arises in relation to the remedy judgment and contends that the ET was wrong to award compensation for pecuniary losses given the application of the </span>
+                            <span style="font-weight:bold;font-family:'Times New Roman';font-size:12pt;color:#000000">NHS Appointment of Consultants Regulations 1996</span>
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#000000"> (“the 1996 Regulations”). </span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_2">
+                    <num style="font-family:'Times New Roman';font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">2.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#000000">For present purposes, I refer to the parties as the claimant and the respondents, as below.  This is the full hearing of the respondents’ appeals against decisions of the London Central ET (Employment Judge Khan, sitting with Ms C I Ihnatowicz and Ms E Flanagan).  The liability judgment was reached after a nine-day full merits hearing, which took place in October and December 2020, with a further three days for deliberations in chambers, and was sent out on 7 May 2021.  The remedy judgment was sent out on 4 January 2022, after a three day hearing in October 2021, with a further day in chambers in early December 2021.  Representation before the ET was as it has been on this appeal. </span>
+                        </p>
+                    </content>
+                </paragraph>
+                <level>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify">
+                            <span style="font-weight:bold;font-family:'Times New Roman';font-size:12pt;color:#000000">The Facts</span>
+                        </p>
+                    </content>
+                </level>
+                <paragraph eId="para_3">
+                    <num style="font-family:'Times New Roman';font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">3.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">The first respondent is an NHS Trust, providing acute and specialist healthcare.  It consists of five London hospitals, including St Mary’s Hospital in Paddington.  The second respondent is the Head of Speciality for Surgery and is a Consultant Colorectal Surgeon.  The claimant was employed by the first respondent at St Mary’s from 10 January 2011 until 23 May 2018.  He and the second respondent were based in the General and Vascular Directorate, which was part of the Surgery, Cancer and Cardiovascular Division; from 2014, the second respondent was the claimant’s line manager.</span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_4">
+                    <num style="font-family:'Times New Roman';font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">4.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">At the date of termination of his employment, the claimant was 59 and had accrued 24 years’ service in the NHS.  Under the terms of his occupational pension scheme, the claimant was able (and intended) to retire at 60, in May 2019. </span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_5">
+                    <num style="font-family:'Times New Roman';font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">5.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">For his first six months at St Mary’s, the claimant was employed as a Senior Clinical Fellow.  Between July 2011 and April 2014, he worked as a Locum Consultant on an “as and when” basis; thereafter, the claimant was employed as a salaried Locum Consultant.  </span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_6">
+                    <num style="font-family:'Times New Roman';font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">6.</num>
+                    <intro>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">It is a statutory requirement under the </span>
+                            <span style="font-weight:bold;font-family:'Times New Roman';font-size:12pt;color:#010302">1996 Regulations</span>
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302"> for a doctor employed in a Consultant post for more than 12 months to be on the Specialist Register (“the Register”) kept by the General Medical Council (“GMC”).  The claimant was not, however, on the Register.  He had applied to join it twice, unsuccessfully, in 2010 and 2011.  Thereafter, he had made no further application and the respondents did not raise this with him at any time prior to December 2017.  In relation to this state of affairs, the ET found as follows:</span>
+                        </p>
+                    </intro>
+                    <subparagraph>
+                        <num style="font-family:'Times New Roman';font-size:12pt;color:#010302">“20.</num>
+                        <content>
+                            <p class="ListParagraph" style="text-align:justify;margin-left:1in;margin-right:0.5in;text-indent:-1in">
+                                <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">… This meant that by continuing to employ the claimant as a locum for more than 12 months the first respondent was contravening the 1996 Reg.  This regulatory issue in so far as it related to the claimant was not identified by the first respondent until July 2017 and the second respondent was made aware of this issue later that year.  We find that this status quo suited the claimant as he was able to do the same work with the same autonomy and pay, and broadly the same status as a substantively employed consultant. He knew from experience that the application process was time-consuming. The claimant also knew that [his named comparator] Mr Hakky had been, like him, employed as a Locum Consultant for several years.  The claimant’s oral evidence, which we accept, was that he had come to understand that specialist registration was not a prerequisite to work as a Consultant.”</span>
+                            </p>
+                        </content>
+                    </subparagraph>
+                </paragraph>
+                <paragraph eId="para_7">
+                    <num style="font-family:'Times New Roman';font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">7.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">During the course of 2017, concerns were raised regarding the claimant’s clinical competence and, on 7 July 2017, it was determined that the claimant’s clinical practice would be restricted pending an investigation into these matters, albeit he was initially assured that the restriction would only last a few weeks.  The nature of the claimant’s restriction was “</span>
+                            <span style="font-style:italic;font-family:'Times New Roman';font-size:12pt;color:#010302">tantamount to an exclusion from work</span>
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">” (paragraph 52, liability judgment); a consequence of this was that any pending appraisal and revalidation were deferred, and it precluded an application for specialist registration. </span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_8">
+                    <num style="font-family:'Times New Roman';font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">8.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">Following the claimant’s restriction, a human resources (“HR”) consultant working for the first respondent, Ms Eaton, discovered that the claimant’s ongoing employment as a Locum Consultant was in breach of the </span>
+                            <span style="font-weight:bold;font-family:'Times New Roman';font-size:12pt;color:#010302">1996 Regulations</span>
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">.  Ms Eaton raised this with others, and a meeting was arranged to discuss the legal, clinical and financial repercussions for the first respondent.  The issue was not, however, raised with the claimant at this time.</span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_9">
+                    <num style="font-family:'Times New Roman';font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">9.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">Meanwhile, Ms Eaton identified other Locum Consultants who also appeared to be employed in contravention of the </span>
+                            <span style="font-weight:bold;font-family:'Times New Roman';font-size:12pt;color:#010302">1996 Regulations</span>
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">; the other Locum Consultants thus identified included Mr Hakky, who was</span>
+                            <span style="font-size:12pt"> appointed as a Locum Consultant in March 2012 and was</span>
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302"> based in the same division as the claimant, but, at 38, was some 20 years younger.  On 17 August 2017, Ms Eaton wrote to divisional directors suggesting an urgent review into the regulatory issue, which would consider: whether the first respondent could support the locum concerned with a Certificate of Eligibility for Specialist Registration (“CESR”); the age of the locum and, if near retirement age, whether early retirement would be possible, in the interests of the efficiency of the service; the length of the locum’s NHS service; likely redundancy costs. </span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_10">
+                    <num style="font-family:'Times New Roman';font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">10.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">The restriction on the claimant’s practice continued to be extended while the investigation into clinical concerns was on-going.  Although parts of the investigation were proceeding under the Maintaining High Professional Standards (“MHPS”) process, which stipulates a maximum extension of four weeks, on 3 October 2017, the claimant was told that his restriction would remain in place “</span>
+                            <span style="font-style:italic;font-family:'Times New Roman';font-size:12pt;color:#010302">for the present time</span>
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">”.  Accepting that the restriction itself remained reasonable, the ET found that the open-nature of the extension contributed to the claimant’s loss of trust and confidence in the first respondent. </span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_11">
+                    <num style="font-family:'Times New Roman';font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">11.</num>
+                    <intro>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">While the claimant remained on restriction, the respondents remained focused on the regulatory issue insofar as it affected other Locum Consultants.  Specifically, in September 2017, the second respondent had raised the issue with Mr Hakky, and, on 11 October 2017, emailed him to say he would need to move onto a new contract, but offering him support and reassurance as follows:</span>
+                        </p>
+                    </intro>
+                    <subparagraph>
+                        <content>
+                            <p class="ListParagraph" style="text-align:justify;margin-left:1in;margin-right:0.5in">
+                                <span style="font-size:12pt">“You will remain, from my point of view and your colleagues, as a consultant colleague with the same role and responsibilities I am happy to support you as I have said before in your application to the specialist registry and hopefully back into a substantive consultant contract I will also try and make sure that financially you are not worse off either…Julie Eaton has already made enquiries into a CESR application for you (i.e. application to the specialist register)…” (see as cited by the ET at paragraph 91 liability judgment)</span>
+                            </p>
+                        </content>
+                    </subparagraph>
+                </paragraph>
+                <paragraph eId="para_12">
+                    <num style="font-family:'Times New Roman';font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">12.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">In contrast, the decision was taken that consultation with the claimant should wait until after the investigation had been completed, in particular as there was no issue relating to the need to supervise his work while he remained on restriction.  That remained the respondents’ position notwithstanding advice from Ms Eaton that the claimant could be informed of the regulatory issue “</span>
+                            <span style="font-style:italic;font-family:'Times New Roman';font-size:12pt;color:#010302">at any time</span>
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">” and that there was a need for a consistent approach “</span>
+                            <span style="font-style:italic;font-family:'Times New Roman';font-size:12pt;color:#010302">so there is no discrimination</span>
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">” (see paragraphs 87-90, liability judgment).</span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_13">
+                    <num style="font-family:'Times New Roman';font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">13.</num>
+                    <intro>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">On 26 October 2017, quotes were sought in respect of a possible redundancy or early retirement payment in respect of the claimant.  The ET did not find this evidenced a predetermined intention to dismiss the claimant, but observed that:</span>
+                        </p>
+                    </intro>
+                    <subparagraph>
+                        <num style="font-family:'Times New Roman';font-size:12pt;color:#010302">“84.</num>
+                        <content>
+                            <p class="ListParagraph" style="text-align:justify;margin-left:1in;margin-right:0.5in;text-indent:-1in">
+                                <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">… the first respondent provided no evidence to show, in the absence of which we do not find, that these steps were also taken in relation to the other locums identified including the claimant’s named comparator, Mr Sherif Mohamed Hakky, …; something which Ms Eaton had, in August 2017, suggested as part of a wider review.  …”</span>
+                            </p>
+                        </content>
+                    </subparagraph>
+                </paragraph>
+                <paragraph eId="para_14">
+                    <num style="font-family:'Times New Roman';font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">14.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.5in">
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">The ET noted that, by this stage, the first respondent had decided that a Locum Consultant affected by the regulatory issue would need to be moved into a more junior role.  In giving evidence to the ET, the first respondent’s Associate Medical Director and Responsible Officer, Mr Vale, had, however, explained that, aware of the claimant’s age and intention to retire, it was felt that it would be difficult for the claimant to revert to a more junior role, which was why the first respondent was looking into the option of early retirement and the cost of uplifting the claimant’s pension.  The ET concluded that these were considerations premised on assumptions relating to the claimant’s age, which Mr Vale, Ms Eaton and the second respondent all held, and which they did not apply to Mr Hakky. </span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_15">
+                    <num style="font-family:'Times New Roman';font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">15.</num>
+                    <intro>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">The ET further recorded the second respondent’s oral evidence that he had had discussions with Mr Vale about Mr Hakky’s position to the effect that, if he moved into a junior role, he could still act up as a Consultant on rotas and have his own clinics if other colleagues were available for support and he had a nominal supervisor.  The second respondent had also discussed this with other Consultants to get their support.  The ET recorded:</span>
+                        </p>
+                    </intro>
+                    <subparagraph>
+                        <num style="font-family:'Times New Roman';font-size:12pt;color:#010302">“92.</num>
+                        <content>
+                            <p class="ListParagraph" style="text-align:justify;margin-left:1in;margin-right:0.5in;text-indent:-1in">
+                                <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">… </span>
+                                <span style="font-size:12pt">In relation to applying to join the Register, the second respondent agreed that the first respondent’s support was an important factor. From the contemporaneous documents we were taken to, we find that the respondents were in no doubt about the interest and willingness of Mr Hakky to make such an application and he was left in [no] doubt as to their willingness to support him with this process</span>.”
+                            </p>
+                        </content>
+                    </subparagraph>
+                </paragraph>
+                <paragraph eId="para_16">
+                    <num style="font-family:'Times New Roman';font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">16.</num>
+                    <intro>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">In relation to Mr Hakky’s position, the second respondent made clear that he “</span>
+                            <span style="font-style:italic;font-family:'Times New Roman';font-size:12pt;color:#010302">would like to be involved so he has support and is not at a disadvantage with this</span>
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">” (paragraph 93, liability judgment).  On 8 December 2017, the second respondent emailed to confirm that he had told Mr Hakky that </span>
+                            <span style="font-size:12pt">“</span>
+                            <span style="font-style:italic;font-size:12pt">clinically little will change as he will still work independently in theatre, clinics and on the consultant on call rota but he will need a consultant supervisor</span>
+                            <span style="font-size:12pt">”; he further explained that the on-call Consultant would supervise Mr Hakky’s on-calls and there would be plenty of Consultants around during the day, an arrangement that Mr Vale “</span>
+                            <span style="font-style:italic;font-size:12pt">was very happy with</span>
+                            <span style="font-size:12pt">” (paragraph 95, liability judgment).  </span>
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">As the ET concluded, while the first respondent intended to transfer Mr Hakky to a Speciality Doctor contract in June 2018, in the meantime, he was being supported to retain the same job duties, with the same autonomy and status, by having his own clinics with a “long stop” Consultant, and he was being actively supported by the first and second respondents in getting on to the Register.  In contrast, it found that:</span>
+                        </p>
+                    </intro>
+                    <subparagraph>
+                        <num style="font-size:12pt">“96.</num>
+                        <content>
+                            <p class="ListParagraph" style="text-align:justify;margin-left:1in;margin-right:0.5in;text-indent:-1in">
+                                <span style="font-size:12pt">… the claimant would be required to work directly alongside another Consultant so that he would not have the same autonomy or status. … for the claimant, this meant being required to work under a new job plan and duties more consonant with the role of a Speciality Doctor than Consultant.”</span>
+                            </p>
+                        </content>
+                    </subparagraph>
+                </paragraph>
+                <paragraph eId="para_17">
+                    <num style="font-family:'Times New Roman';font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">17.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">Dr Hakky applied to join the Register in 2019 but his application was rejected and was then re-submitted, by way of appeal.  Although the first respondent’s Head of Employee Relations warned that the arrangement should not continue, the decision was taken to retain Mr Hakky on his Locum Consultant contract pending the outcome of his appeal.  That contract was then extended to the end of July 2020 and, as at the date of the ET full merits hearing, Mr Hakky remained employed by the first respondent as a Locum Consultant, having continued to work in a Consultant capacity throughout. </span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_18">
+                    <num style="font-family:'Times New Roman';font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">18.</num>
+                    <intro>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">The ET noted that none of the correspondence relating to the treatment of Mr Hakky and the claimant regarding these contractual issues had been disclosed by the respondents until day four of the full merits hearing; it found that:</span>
+                        </p>
+                    </intro>
+                    <subparagraph>
+                        <num style="font-family:'Times New Roman';font-size:12pt;color:#010302">“99.</num>
+                        <content>
+                            <p class="ListParagraph" style="text-align:justify;margin-left:1in;margin-right:0.5in;text-indent:-1in">
+                                <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">… </span>
+                                <span style="font-size:12pt">This was an inexplicable failure to disclose documents which were self-evidently and centrally relevant to this claim, which involved senior and experienced HR professionals, in addition to the second respondent and Mr Vale, and which illustrate the more favourable treatment of Mr Hakky in which the second respondent took an active part in encouraging, supporting and advocating for him, and both respondents supported him to remain in post notwithstanding the regulatory issue; and specifically: a. He was consulted with in relation to the regulatory issue from September 2017. b. He was told that he would continue to be seen by his colleagues as a Consultant with the same role and responsibilities. c. He was told that steps would be taken to mitigate the reduction to his pay. d. He was supported in retaining the same duties before it was agreed that his Locum Contract would be extended. e. He was encouraged and supported to make an application to join the Register. f. He was retained in the same role and on the same pay pending his specialist registration more than three years after this regulatory issue had been identified.”</span>
+                            </p>
+                        </content>
+                    </subparagraph>
+                </paragraph>
+                <paragraph eId="para_19">
+                    <num style="font-family:'Times New Roman';font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">19.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">Returning to the investigation relating to the claimant, this was completed by December 2017; it concluded that there were issues relating to the claimant’s communication but not his clinical performance.  From that point, there was no need to restrict the claimant’s practice to protect patients and the ET found it was “</span>
+                            <span style="font-style:italic;font-family:'Times New Roman';font-size:12pt;color:#010302">incumbent on Mr Vale to lift this restriction once he had discussed these findings with the claimant</span>
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">” (paragraph 103, liability judgment).  Moreover, it was Mr Vale’s evidence that none of the investigation findings warranted the claimant’s dismissal and he had anticipated resolving the matter informally, without further delay.  To the extent that a disciplinary process might need to be followed, Mr Vale had envisaged a sanction no higher than a first written warning. </span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_20">
+                    <num style="font-family:'Times New Roman';font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">20.</num>
+                    <intro>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">On 22 December 2017, the claimant attended an informal meeting with Mr Vale and Ms Eaton to discuss the investigation report.  At this meeting, Mr Vale also referred to the regulatory issue, saying that, in terms of “</span>
+                            <span style="font-style:italic;font-family:'Times New Roman';font-size:12pt;color:#010302">future plans</span>
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">”, this meant the claimant could not remain in his post and would be moved to the role of Speciality Doctor, with a revised job plan.  The claimant understood this was a more junior, supervised role, without the same autonomy, which was not acceptable to him.  He referred to his intention to retire at 60, in 2019, and Mr Vale agreed to discuss the job plan and the lifting of the claimant’s practice restriction with the second respondent.  The claimant was, however, not invited to make an application for specialist registration and the ET found that, when he conveyed his intention to remain working in an autonomous capacity until his 60</span>
+                            <span style="vertical-align:super;font-size:12pt;font-family:'Times New Roman';color:#010302">th</span>
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302"> birthday by means which did not involve applying to join the Register, Mr Vale and Ms Eaton assumed he was neither interested nor willing to proceed with such an application.  As the ET recorded:</span>
+                        </p>
+                    </intro>
+                    <subparagraph>
+                        <num style="font-size:12pt">“110.</num>
+                        <content>
+                            <p class="ListParagraph" style="text-align:justify;margin-left:1in;margin-right:0.5in;text-indent:-1in">
+                                <span style="font-size:12pt">… In their oral evidence, Ms Eaton agreed that the claimant was not invited to apply to the Register and Mr Vale agreed that the claimant was not given any encouragement to apply. They did not therefore explore this with him at this meeting and failed to establish whether the claimant wished to be supported with a CESR application, which was one of the steps [they] … had [been] told … it was necessary to take in relation to the locum consultants. Nor had the claimant been treated the same way as Mr Hakky and given the same reassurances and encouragement from the second respondent. Having been restricted for over five months, he had, unlike Mr Hakky, been told that he was required to return to an amended and supervised role. The consequence of all of this was that the claimant did not actively consider making an application to join the Register.”</span>
+                            </p>
+                        </content>
+                    </subparagraph>
+                </paragraph>
+                <paragraph eId="para_21">
+                    <num style="font-family:'Times New Roman';font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">21.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">The ET further noted that the decision to delay consultation with the claimant regarding the regulatory issue meant he had lost the opportunity to use the previous five months to gather evidence to support an application to join the Register once his restriction had ended.  Given that Ms Eaton had advised, back in October 2017, that the claimant could have been informed at “</span>
+                            <span style="font-style:italic;font-family:'Times New Roman';font-size:12pt;color:#010302">any time</span>
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">”, the ET did not find that the fact of his restriction put him in materially different circumstances from Mr Hakky in this respect. </span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_22">
+                    <num style="font-family:'Times New Roman';font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">22.</num>
+                    <intro>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">On 5 January 2018, Mr Vale wrote to the claimant, confirming that he could not be retained as a Locum Consultant because he was not on the Register and had not taken the steps necessary to join it.  As the ET found: </span>
+                        </p>
+                    </intro>
+                    <subparagraph>
+                        <num style="font-family:'Times New Roman';font-size:12pt;color:#010302">“112.</num>
+                        <content>
+                            <p class="ListParagraph" style="text-align:justify;margin-left:1in;margin-right:0.5in;text-indent:-1in">
+                                <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">… </span>
+                                <span style="font-size:12pt">This was written in definitive terms in which no reference was made to either the prospect of any steps being made or to a refusal by the claimant to take any. Mr Vale explained that it was necessary for doctors in the same position as the claimant to change to speciality doctors save for “a few” other colleagues who were in the same position whose inclusion in the Register was imminent. …”</span>
+                            </p>
+                        </content>
+                    </subparagraph>
+                </paragraph>
+                <paragraph eId="para_23">
+                    <num style="font-family:'Times New Roman';font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">23.</num>
+                    <intro>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">Mr Vale and Ms Easton met with the second respondent on 9 January 2018 with a view to his drawing up a revised job plan for the claimant to enable him to return to work in the role of Speciality Doctor.  It was Mr Vale’s evidence that he could not permit the claimant to return to his Locum Consultant duties.  As a consequence, the claimant’s restriction remained in force pending his intended return in an amended role; that, the ET found, was the reason for his continued restriction from January 2018.  In oral evidence, Mr Vale agreed, however, that this restriction should have ended sooner: it was serious, risked de-skilling, carried stigma and caused reputational damage.  The ET found this had the effect of damaging the claimant’s trust and confidence in the first respondent and noted that the same approach was not taken with Mr Hakky:</span>
+                        </p>
+                    </intro>
+                    <subparagraph>
+                        <num style="font-family:'Times New Roman';font-size:12pt;color:#010302">“114.</num>
+                        <content>
+                            <p class="ListParagraph" style="text-align:justify;margin-left:1in;margin-right:0.5in;text-indent:-1in">
+                                <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">… </span>
+                                <span style="font-size:12pt">As the second respondent said in oral evidence, a new job plan was not needed for Mr Hakky because it had been decided that he could continue in the same role.”</span>
+                            </p>
+                        </content>
+                    </subparagraph>
+                </paragraph>
+                <paragraph eId="para_24">
+                    <num style="font-family:'Times New Roman';font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">24.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">The claimant responded to the investigation findings on 1 February 2018, saying he “</span>
+                            <span style="font-style:italic;font-family:'Times New Roman';font-size:12pt;color:#010302">strongly disagree[d]”</span>
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302"> with the “</span>
+                            <span style="font-style:italic;font-family:'Times New Roman';font-size:12pt;color:#010302">false allegations</span>
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">”.  Mr Vale felt that this lacked insight and it was therefore appropriate to proceed with a formal disciplinary process.  The ET accepted that this was a reasonable step to take in these circumstances. </span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_25">
+                    <num style="font-family:'Times New Roman';font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">25.</num>
+                    <intro>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">Shortly after this, in an email of 14 February 2018, reference was made to notice arrangements for Mr Hakky, which gave rise to the following clarification: </span>
+                        </p>
+                    </intro>
+                    <subparagraph>
+                        <content>
+                            <p class="ListParagraph" style="text-align:justify;margin-left:1in;margin-right:0.5in">
+                                <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">“… Mr Hakky is not leaving us soon, I think she has mixed him up with [the claimant]” (paragraph 122, liability judgment)</span>
+                            </p>
+                        </content>
+                    </subparagraph>
+                    <subparagraph>
+                        <content>
+                            <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                                <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">The ET considered this revealed the different ways in which the respective career trajectories of the claimant and Mr Hakky were viewed. </span>
+                            </p>
+                        </content>
+                    </subparagraph>
+                </paragraph>
+                <paragraph eId="para_26">
+                    <num style="font-family:'Times New Roman';font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">26.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">On 1 March 2018, the claimant was sent a letter giving him three months’ notice that he would be transferred to the role of Speciality Doctor on 1 June 2018.  A letter in the same terms was sent out on the same day to Mr Hakky, although this prompted an intervention by the second respondent, who reported that Mr Hakky had obtained advice from the British Medical Association (“BMA”) that his pay could not be reduced.  </span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_27">
+                    <num style="font-family:'Times New Roman';font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">27.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">A week later, the claimant was invited to a disciplinary hearing, scheduled for 8 May 2018; he was warned that one outcome might be his dismissal.  Accepting that was standard wording, given that Mr Vale had confirmed that none of the investigation findings warranted dismissal, the ET found that the inclusion of this warning and the delay in holding the hearing further damaged the claimant’s trust and confidence. </span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_28">
+                    <num style="font-family:'Times New Roman';font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">28.</num>
+                    <intro>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">On 29 March 2018, the BMA wrote to Mr Vale raising concerns about the claimant’s ongoing restriction.  When Mr Vale forwarded this to Ms Eaton, she advised that there was no justification in keeping the claimant restricted pending the hearing and said that the claimant was able to undertake his clinical duties as Locum Consultant until his change of contract took effect (as was the case with Mr Hakky).  Notwithstanding that advice, Mr Vale responded to the BMA on 4 April 2018, to confirm that the claimant’s restriction would be extended for a further two weeks to enable arrangements for his return to a supervised role to be agreed.  Although it was unclear when the second respondent drafted a reviewed job description for the claimant, the ET noted that more than three months had passed since he had been tasked with this work; it found:</span>
+                        </p>
+                    </intro>
+                    <subparagraph>
+                        <num style="font-size:12pt">“129.</num>
+                        <content>
+                            <p class="ListParagraph" style="text-align:justify;margin-left:1in;margin-right:0.5in;text-indent:-1in">
+                                <span style="font-size:12pt">… the second respondent, cognisant of the claimant’s opposition to moving to a role which involved the loss of autonomy and status, was himself reluctant to broach this issue with the claimant. We also find that the open-ended nature of the claimant’s restriction permitted this ongoing delay. These factors combined to prolong the claimant’s restriction until the BMA’s intervention. </span>
+                            </p>
+                        </content>
+                    </subparagraph>
+                    <subparagraph>
+                        <content>
+                            <p class="ListParagraph" style="text-align:justify;margin-left:1in;margin-right:0.5in">
+                                <span style="font-size:12pt">130.The second respondent’s reluctance to engage with the claimant and take the necessary steps to facilitate his return to work contrasted starkly with the steps he took to support Mr Hakky. The second respondent had to be instructed by HR to contact the claimant to facilitate his return without further delay. Ms Eaton … told him that the claimant could be allocated the duties of a Speciality Doctor even if he had not responded to this offer. When the second respondent replied that he had not heard from the claimant, … [it was] emphasised that it was necessary for the second respondent to tell the claimant that his restriction had ended and was required to report for work, and to meet with him and give him his new job plan.”</span>
+                            </p>
+                        </content>
+                    </subparagraph>
+                </paragraph>
+                <paragraph eId="para_29">
+                    <num style="font-family:'Times New Roman';font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">29.</num>
+                    <intro>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">On 20 April 2018, the claimant emailed the second respondent to confirm that he was ready to resume work on 23 April.  He made clear, however, that he considered his new job plan to be an insult, and unacceptable as it ignored his experience.  Ms Eaton advised the second respondent that the claimant could return to his Consultant duties until his contract expired, but the second respondent failed to relay this to the claimant, who understood that he was required to return to work under the revised job plan and submitted a grievance regarding this on 23 April 2018.  Ms Eaton’s response the next day was to confirm that the claimant was required to attend work without delay “</span>
+                            <span style="font-style:italic;font-family:'Times New Roman';font-size:12pt;color:#010302">to undertake the duties as set out</span>
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">” by the second respondent.  As the ET observed: </span>
+                        </p>
+                    </intro>
+                    <subparagraph>
+                        <num style="font-size:12pt">“131.</num>
+                        <content>
+                            <p class="ListParagraph" style="text-align:justify;margin-left:1in;margin-right:0.5in;text-indent:-1in">
+                                <span style="font-size:12pt">… The claimant therefore understood the requirement to perform the duties under the new job plan remained applicable to him and he did not return to work.”  </span>
+                            </p>
+                        </content>
+                    </subparagraph>
+                </paragraph>
+                <paragraph eId="para_30">
+                    <num style="font-family:'Times New Roman';font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">30.</num>
+                    <intro>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">Although the claimant met with the second respondent on 10 May 2018, his position was not resolved and the claimant was concerned that his annual appraisal was now overdue.  The ET found:</span>
+                        </p>
+                    </intro>
+                    <subparagraph>
+                        <num style="font-family:'Times New Roman';font-size:12pt;color:#010302">“135.</num>
+                        <content>
+                            <p class="ListParagraph" style="text-align:justify;margin-left:1in;margin-right:0.5in;text-indent:-1in">
+                                <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">…</span>
+                                <span style="font-size:12pt"> the second respondent … failed to take any steps to support the claimant with this process. He also confirmed that he would not book any patients for the claimant because he had not agreed to work in another Consultant’s clinic. We find that the ongoing failure to facilitate the claimant’s return to his substantive duties and to support him with his appraisal which he had been unable to complete during his extended restriction had the effect of damaging his trust and confidence in the first respondent. We also find that the respondents had therefore failed to preserve his role in the same way as was done with Mr Hakky.”</span>
+                            </p>
+                        </content>
+                    </subparagraph>
+                </paragraph>
+                <paragraph eId="para_31">
+                    <num style="font-family:'Times New Roman';font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">31.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">On 15 May 2018, the claimant accepted the investigation findings.  His letter in this regard crossed, however, with a further letter sent out by Mr Vale relating to arrangements for the disciplinary hearing.  Although the threat of dismissal was removed, the letter still referred to the possibility of disciplinary action up to a final written warning.  The ET found this contradicted earlier statements of intent to resolve matters informally and, by failing to withdraw the threat of disciplinary action once the claimant had demonstrated the necessary self-reflection, this again damaged trust and confidence. </span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_32">
+                    <num style="font-family:'Times New Roman';font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">32.</num>
+                    <intro>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">On 23 May 2018, the claimant was sent a new contract for the role of Speciality Doctor, due to start 1 June 2018.  He resigned the same day, with immediate effect, complaining that he had lost all trust and confidence in the first respondent as a result of a series of breaches, culminating in the refusal to allow him to return to his substantive duties since 23 April 2018.  Although Ms Eaton invited him to reconsider, at least pending a meeting with the interim Medical Director (Professor Orchard) the following week, the claimant was not prepared to do so; as the ET accepted:</span>
+                        </p>
+                    </intro>
+                    <subparagraph>
+                        <num style="font-family:'Times New Roman';font-size:12pt;color:#010302">“141.</num>
+                        <content>
+                            <p class="ListParagraph" style="text-align:justify;margin-left:1in;margin-right:0.5in;text-indent:-1in">
+                                <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">… </span>
+                                <span style="font-size:12pt">as a result of his extended restriction, the threat of disciplinary action and his fear about the regulatory consequences of not having completed his appraisal he had lost confidence that the first respondent would enable him to work again or that it was safe for him to return.”</span>
+                            </p>
+                        </content>
+                    </subparagraph>
+                </paragraph>
+                <paragraph eId="para_33">
+                    <num style="font-family:'Times New Roman';font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">33.</num>
+                    <intro>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">At around the same time, Mr Hakky and the first respondent agreed that he would continue in his Locum Consultant role pending his application to the Register.  As Ms Eaton confirmed at the time, the approach taken in relation to Mr Hakky was as follows: </span>
+                        </p>
+                    </intro>
+                    <subparagraph>
+                        <content>
+                            <p class="ListParagraph" style="text-align:justify;margin-left:1in;margin-right:0.5in">
+                                <span style="font-size:12pt">“The intention is for Mr Hakky to actively pursue his CESR, which he is doing with assistance …. Further extensions of contract will be necessary for him to achieve this (he will be submitting all the documentation to the GMC at the end of November)…” (paragraph 139, liability judgment)</span>
+                            </p>
+                        </content>
+                    </subparagraph>
+                    <subparagraph>
+                        <content>
+                            <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                                <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">The ET recorded that t</span>
+                                <span style="font-size:12pt">he second respondent replied “</span>
+                                <span style="font-style:italic;font-size:12pt">Thanks very much[.] That is much better…</span>
+                                <span style="font-size:12pt">” and enquired about the process for appointing Mr Hakky to a substantive post in due course.</span>
+                            </p>
+                        </content>
+                    </subparagraph>
+                </paragraph>
+                <paragraph eId="para_34">
+                    <num style="font-family:'Times New Roman';font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">34.</num>
+                    <intro>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">Had the claimant not resigned and had then attended the meeting with Professor Orchard the following week, the first respondent’s proposal for his continued employment was anticipated in internal email correspondence as follows (see as cited at paragraph 41, remedy judgment):</span>
+                        </p>
+                    </intro>
+                    <subparagraph>
+                        <content>
+                            <p class="ListParagraph" style="text-align:justify;margin-left:1in;margin-right:0.5in">
+                                <span style="font-size:12pt">“As you are aware we have been trying to resolve the employment situation of [the claimant], who has been employed by the Trust and the Division outside the Appointment of Consultants Regulations as a locum consultant since April 2014...He has been offered a speciality doctor post at a considerably lesser salary which he has declined and effectively unless we find a solution we will have terminated his contract at the end of this month. The Division has previously explored the option of redundancy but this option is not viable for financial reasons. Quite separate to this, the Division has raised issues about his competence which have been largely resolved through investigation of the issues raised including two Serious Incidents. [The claimant]’s communication was criticised, but his surgical skills and judgement were not found to be below an acceptable standard. Through the Medical Director’s office we have been in on-going discussions with the BMA about a possible resolution. We have reached a point where resolution is possible without dismissal but this will involve extending his contract for a final period not to exceed 6 months + a 3 month notice period effectively an extended notice period of 9 months terminating his contract under a settlement agreement at the end of February 2019. During this time we will be able to use his services on locum consultant duties as before. I am therefore seeking your agreement to pursuing this option with the BMA which will effectively resolve the situation without recourse to legal action or further financial costs…” </span>
+                            </p>
+                        </content>
+                    </subparagraph>
+                    <subparagraph>
+                        <content>
+                            <p class="ListParagraph" style="text-align:justify;margin-left:1in;margin-right:0.5in">
+                                <span style="font-size:12pt">“[Ms Eaton] has offered the BMA rep a solution which involves [the claimant] confirming (via a legal agreement) that he will leave us on 31 March 2019, but will continue to be called a locum consultant and paid as such.” </span>
+                            </p>
+                        </content>
+                    </subparagraph>
+                    <subparagraph>
+                        <intro>
+                            <p style="text-align:justify;margin-left:0.5in;margin-right:0.5in">
+                                <span style="font-size:12pt">When it was queried how the claimant could retain the same title without a CCST, the ET noted that it was explained: </span>
+                            </p>
+                        </intro>
+                        <subparagraph>
+                            <content>
+                                <p class="ListParagraph" style="text-align:justify;margin-left:1in;margin-right:0.5in">
+                                    <span style="font-size:12pt"> “He can be called locum consultant without being on the Speciality Register and can continue to be employed with the MDO’s [Medical Director’s Office’s] permission.”</span>
+                                </p>
+                            </content>
+                        </subparagraph>
+                    </subparagraph>
+                </paragraph>
+                <paragraph eId="para_35">
+                    <num style="font-family:'Times New Roman';font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">35.</num>
+                    <intro>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">The ET concluded that this proposal, which involved the Medical Director’s Office and senior HR advisers, was the first respondent’s “</span>
+                            <span style="font-style:italic;font-family:'Times New Roman';font-size:12pt;color:#010302">solution</span>
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">”, explored on an “</span>
+                            <span style="font-style:italic;font-family:'Times New Roman';font-size:12pt;color:#010302">exceptional basis</span>
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">”, to retain the claimant as a Locum Consultant in order to resolve this dispute:</span>
+                        </p>
+                    </intro>
+                    <subparagraph>
+                        <content>
+                            <p class="ListParagraph" style="text-align:justify;margin-left:1in;margin-right:0.5in">
+                                <span style="font-size:12pt">“We do not find that the first respondent took the view that this was ultra vires at the time (nor the alternative arrangements it agreed with Mr Hakky, in early June 2018, to retain him on a locum consultant contract whilst he went through the protracted CESR process) because it was sanctioned by the MDO.”</span>
+                            </p>
+                        </content>
+                    </subparagraph>
+                </paragraph>
+                <paragraph eId="para_36">
+                    <num style="font-family:'Times New Roman';font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">36.</num>
+                    <intro>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">The ET further accepted the evidence of Ms Eaton, as follows:</span>
+                        </p>
+                    </intro>
+                    <subparagraph>
+                        <num style="font-size:12pt">“42.</num>
+                        <content>
+                            <p class="ListParagraph" style="text-align:justify;margin-left:1in;margin-right:0.5in;text-indent:-1in">
+                                <span style="font-size:12pt">… had the claimant remained employed, the first respondent would have offered to extend his locum consultant contract for another nine months and it is highly likely that this offer would have been extended by another three months to coincide with the claimant’s 60th birthday, and intended retirement date.”</span>
+                            </p>
+                        </content>
+                    </subparagraph>
+                </paragraph>
+                <level>
+                    <content>
+                        <p style="text-align:justify;margin-right:0.24in">
+                            <span style="font-weight:bold;font-family:'Times New Roman';font-size:12pt;color:#010302">The ET Liability Decision</span>
+                        </p>
+                    </content>
+                </level>
+                <paragraph eId="para_37">
+                    <num style="font-family:'Times New Roman';font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">37.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">The claimant brought complaints of constructive unfair and wrongful dismissal and of direct age discrimination, age-related harassment and victimisation.  The allegations relied on by the claimant were set out within a list of issues, from (a)-(dd).  As a result of late disclosure by the respondents, on the fourth day of the ET hearing, the claimant was permitted to amend his claim to add further allegations (ee) to (jj).  The ET upheld the claimant’s claims of unfair and wrongful dismissal and, in part, the complaints of direct age discrimination.  The focus of this appeal is on the findings of direct age discrimination.</span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_38">
+                    <num style="font-family:'Times New Roman';font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">38.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">The ET found that the following matters (here paraphrased for ease of understanding)  amounted to unjustified less favourable treatment because of age: issue (n) from January 2018, the restriction on the claimant’s practice was extended for an undefined period and, in breach of MHPS, was not then kept under review; issue (t) although the disciplinary investigation did not find any serious clinical allegations proven, and Mr Vale was prepared to treat the communication issues as learning points, from January 2018, the restriction on the claimant’s practice continued without limit; issue (x) from January 2018, the respondents failed to review the restriction on the claimant’s practice, deliberately ignoring advice from Ms Eaton that there were insufficient grounds to continue the restriction; issue (y) more generally, the respondents obstructed the claimant’s return to work to the position of Locum Consultant and failed to conduct his annual appraisal; issue (ee) in contrast to their treatment of Mr Hakky, between May and December 2017, the respondents failed to warn the claimant that they were proposing to terminate his Locum Consultant contract by reason of his not being on the Register; issue (ff) again in contrast to their treatment of Mr Hakky, from May 2017 to the time of his resignation, the respondents failed to proffer or provide support to the claimant in the form of encouragement to apply to the Register; issue (gg) in contrast to the position regarding Mr Hakky, the respondents failed to inform the claimant that he would, after the termination of his Locum Consultant post, “</span>
+                            <span style="font-style:italic;font-family:'Times New Roman';font-size:12pt;color:#010302">remain from the point of view [of the respondents] and your colleagues, as a Consultant colleague with the same role and responsibilities</span>
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">”; issue (hh) in contrast to Mr Hakky, the respondents failed to reassure the claimant that, on termination of his Locum Consultant contract, they would “</span>
+                            <span style="font-style:italic;font-family:'Times New Roman';font-size:12pt;color:#010302">try and make sure that financially you are not worse off</span>
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">”; issue (ii) in contrast to Mr Hakky (at least up to 2020), the respondents failed to inform the claimant that he would be permitted to complete an application for the Register whilst retaining his Consultant rate of pay; issue (jj) the respondents changed the claimant’s role so that he was working in other Consultants’ clinics, failing (in contrast to Mr Hakky) to preserve the nature of his role.</span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_39">
+                    <num style="font-family:'Times New Roman';font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">39.</num>
+                    <intro>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">The ET explained its conclusion on the section 13 claim, as follows:</span>
+                        </p>
+                    </intro>
+                    <subparagraph>
+                        <num style="font-family:'Times New Roman';font-size:12pt;color:#010302">“197.</num>
+                        <content>
+                            <p class="ListParagraph" style="text-align:justify;margin-left:1in;margin-right:0.5in;text-indent:-1in">
+                                <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">… We find that the claimant has established a prima facie case and the respondents have failed to show that this treatment was in no sense whatsoever because of his age, due to the following: (1) The more favourable treatment of Mr Hakky … who other than his age was in materially the same circumstances as the claimant. (2) The extent and duration of this treatment. (3) The lack of a cogent explanation for this disparate treatment. (4) The first respondent’s exploration of the costs of terminating the claimant’s employment because of age-related assumptions shared by the second respondent, Mr Vale and Ms Eaton in relation to the claimant’s intention to retire and his reluctance to accept a more junior role. (5) The failure of the first respondent to enquire about the likelihood of the claimant applying to join the Register and to invite or encourage him to make a CESR application. (6) The second respondent’s delay in drafting the revised job plan and reluctance to meet with the claimant to facilitate his return to work. (7) The failure to disclose timeously documents which were self-evidently and centrally relevant to this claim, from which we draw an adverse inference.”</span>
+                            </p>
+                        </content>
+                    </subparagraph>
+                </paragraph>
+                <paragraph eId="para_40">
+                    <num style="font-family:'Times New Roman';font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">40.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">The ET further found that the discriminatory conduct identified by issues (n), (t) (x) and (y), was a material part of the repudiatory conduct on which the claimant relied when he resigned (issue (aa)); it therefore held that this amounted to a discriminatory dismissal. </span>
+                        </p>
+                    </content>
+                </paragraph>
+                <level>
+                    <content>
+                        <p style="text-align:justify;margin-right:0.24in">
+                            <span style="font-weight:bold;font-family:'Times New Roman';font-size:12pt;color:#010302">The ET Remedy Decision</span>
+                        </p>
+                    </content>
+                </level>
+                <paragraph eId="para_41">
+                    <num style="font-family:'Times New Roman';font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">41.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">The ET addressed the question of remedy at a separate hearing in October 2021.  It considered the position had the claimant been informed of the regulatory issue at the same time as Mr Hakky, in October 2017, and had returned to practice in January 2018, concluding it was unlikely that the claimant would in fact have applied to join the Register.</span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_42">
+                    <num style="font-family:'Times New Roman';font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">42.</num>
+                    <intro>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">The ET considered that the claimant would thus have faced the choice between moving to a Speciality Doctor role or remaining “</span>
+                            <span style="font-style:italic;font-family:'Times New Roman';font-size:12pt;color:#010302">in situ</span>
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">” until he turned 60.  It found that he would have chosen the latter option:</span>
+                        </p>
+                    </intro>
+                    <subparagraph>
+                        <num style="font-size:12pt">“40.</num>
+                        <content>
+                            <p class="ListParagraph" style="text-align:justify;margin-left:1in;margin-right:0.5in;text-indent:-1in">
+                                <span style="font-size:12pt">… The claimant was adamant that he would not move into the role of Speciality Doctor which required him to be supervised, and had a significantly lower salary and status. (We note here that the assurances which the second respondent gave to Mr Hakky in October 2017 and February 2018 were ultimately ineffective, because he challenged his putative transfer to a Speciality Doctor role which resulted in the agreement that he would be retained in his locum role and supported with making an application to join the Register in the meantime, and we find such assurances would also have been ineffective with the claimant, had they been given by the second respondent, not least because of the loss of trust between them for reasons which were unrelated to the discriminatory conduct we have found.)”</span>
+                            </p>
+                        </content>
+                    </subparagraph>
+                </paragraph>
+                <paragraph eId="para_43">
+                    <num style="font-family:'Times New Roman';font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">43.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">Had the claimant continued in his employment, the ET thus considered that he would have accepted the first respondent’s proposal that his Locum Consultant contract would be extended for another nine months, and that this would then have been extended by another three months to coincide with his intended retirement date. </span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_44">
+                    <num style="font-family:'Times New Roman';font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">44.</num>
+                    <intro>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">The ET acknowledged that this agreement would have been rendered </span>
+                            <span style="font-style:italic;font-family:'Times New Roman';font-size:12pt;color:#010302">ultra vires</span>
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302"> by the </span>
+                            <span style="font-weight:bold;font-family:'Times New Roman';font-size:12pt;color:#010302">1996 Regulations</span>
+                            <span style="font-family:'Times New Roman';font-size:12pt;color:#010302">, but found:</span>
+                        </p>
+                    </intro>
+                    <subparagraph>
+                        <num style="font-size:12pt">“49.</num>
+                        <content>
+                            <p class="ListParagraph" style="text-align:justify;margin-left:1in;margin-right:0.5in;text-indent:-1in">
+                                <span style="font-size:12pt">… there would have been a subsisting employment relationship which would not: the claimant would have been employed lawfully throughout. This is what obtained with Mr Hakky until the date when he joined the Register. As the [EAT] … held in Lairikyengbam the fact that the ongoing employment of L was ultra vires did not preclude the existence of a lawful employment contract.”</span>
+                            </p>
+                        </content>
+                    </subparagraph>
+                </paragraph>
+                <level>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify">
+                            <span style="font-weight:bold;font-size:12pt">Liability: The Grounds of Appeal and the Parties’ Submissions</span>
+                        </p>
+                    </content>
+                </level>
+                <paragraph eId="para_45">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">45.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">The respondents’ appeal against the ET’s liability judgment was permitted to proceed on four grounds of appeal, as follows: (1) the ET did not apply the correct legal test under section 13 </span>
+                            <span style="font-weight:bold;font-size:12pt">EqA</span>
+                            <span style="font-size:12pt">, rather than asking whether the treatment was “</span>
+                            <span style="font-style:italic;font-size:12pt">because of age</span>
+                            <span style="font-size:12pt">” it applied a looser causal test, asking whether the treatment related to age; (2) further/alternatively, the ET erred in its approach to the question of causation because it failed to ask what were the respondents’ </span>
+                            <span style="font-style:italic;font-size:12pt">subjective</span>
+                            <span style="font-size:12pt"> reasons for the impugned treatment? (3) separately, the ET erred in applying an objective test when analysing whether the comparator, Mr Hakky, was treated more favourably; (4) the ET’s conclusion was perverse. </span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_46">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">46.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">In respect of ground (1), the respondents submit: (a) the ET concluded that the respondents had explored the cost of terminating the claimant’s appointment because of two “</span>
+                            <span style="font-style:italic;font-size:12pt">age-related assumptions</span>
+                            <span style="font-size:12pt">”, namely (paragraph 84, liability judgment) (i) it would be difficult for the claimant to move to a junior role; and (ii) it was the claimant’s intention to retire early; (b) it asked whether these matters </span>
+                            <span style="font-style:italic;font-size:12pt">related</span>
+                            <span style="font-size:12pt"> to age, rather than asking whether this was less favourable treatment </span>
+                            <span style="font-style:italic;font-size:12pt">because of</span>
+                            <span style="font-size:12pt"> age; (c) the concepts of a retirement date and an unwanted junior role might be </span>
+                            <span style="font-style:italic;font-size:12pt">related to</span>
+                            <span style="font-size:12pt"> age, but that did not necessarily mean that any treatment done on those grounds must therefore be </span>
+                            <span style="font-style:italic;font-size:12pt">by reason</span>
+                            <span style="font-size:12pt"> of age (this was not a </span>
+                            <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt">James v Eastleigh Borough Council</span>
+                            <span style="font-size:12pt">
+                                <ref href="#" uk:canonical="[1990] ICR 554" uk:isNeutral="false" uk:origin="TNA" uk:type="case" uk:year="1990">[1990] ICR 554</ref> HL case); (d) these were the only factors relied upon by the ET to conclude that the treatment of the claimant was linked with age and were fundamental to its final decision on section13 </span>
+                            <span style="font-weight:bold;font-size:12pt">EqA</span>
+                            <span style="font-size:12pt">. </span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_47">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">47.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">For the claimant it is said that the ET was aware that the test in relation to issues of direct age discrimination was whether the relevant treatment was </span>
+                            <span style="font-style:italic;font-size:12pt">because of</span>
+                            <span style="font-size:12pt"> age (see the ET’s legal directions) and it was plain the ET determined each matter in relation to section 13 </span>
+                            <span style="font-weight:bold;font-size:12pt">EqA</span>
+                            <span style="font-size:12pt"> as to whether it was </span>
+                            <span style="font-style:italic;font-size:12pt">because of</span>
+                            <span style="font-size:12pt"> age.</span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_48">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">48.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">As for ground (2), the respondents contend: (a) by requiring that the respondents provide a “</span>
+                            <span style="font-style:italic;font-size:12pt">cogent</span>
+                            <span style="font-size:12pt">” explanation for the impugned treatment, as opposed to an explanation that was not related to age, the ET failed to have proper regard to its findings of fact and to the respondents’ subjective reasons for their treatment of the claimant; (b) a proper analysis of the ET’s findings of fact showed that the respondents’ treatment of the claimant (even if not “</span>
+                            <span style="font-style:italic;font-size:12pt">cogent</span>
+                            <span style="font-size:12pt">”) was not </span>
+                            <span style="font-style:italic;font-size:12pt">because of</span>
+                            <span style="font-size:12pt"> age (in particular, the ET had found that the extension of the claimant’s restriction, and the postponement of a discussion about the regulatory issue, was because of the ongoing investigation/disciplinary).</span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_49">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">49.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">The claimant responds: (a) the ET correctly directed itself on the burden of proof; (b) it was the ET’s task to assess the cogency of the evidence - that was part and parcel of the process of appraising the respondent’s evidence in support of their asserted reasons - it did not thereby substitute the test of cogency for the </span>
+                            <span style="font-style:italic;font-size:12pt">reason why</span>
+                            <span style="font-size:12pt">; (c) having heard the respondents’ evidence, tested under cross-examination, and challenged by the claimant’s evidence and submissions, the ET plainly rejected the reasons relied on; (d) the respondents had failed to prove their actions were not by reason of age - the cogency of the evidence was one of a series of reasons set out by the ET for its conclusion. </span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_50">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">50.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">In addressing ground (3), the respondents make the following points: (a) the ET found Mr Vale decided not to consult with the claimant about the regulatory issue because of the ongoing investigation and practice restrictions, but then held this was not a material difference because the first respondent </span>
+                            <span style="font-style:italic;font-size:12pt">could </span>
+                            <span style="font-size:12pt">still have consulted with the claimant about that matter; (b) the ET thereby (i) wrongly conducted an objective assessment of whether it was reasonable for the first respondent to treat Mr Hakky’s circumstances as different (see </span>
+                            <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt">Shamoon v Chief Constable of the Royal Ulster Constabulary</span>
+                            <span style="font-size:12pt">
+                                <ref href="https://caselaw.nationalarchives.gov.uk/ukhl/2003/11" uk:canonical="[2003] UKHL 11" uk:isNeutral="true" uk:origin="TNA" uk:type="case" uk:year="2003">[2003] UKHL 11</ref> per Lord Roger at 132) and (ii) failed to take into account its findings of fact as to the circumstances that the first respondent had taken into account when dealing with the claimant (which were very different from those of Mr Hakky, who was not the subject of an investigation/disciplinary, was at work at the relevant time, and when the respondents had no doubt that he was willing to apply to join the Register); (c) had the ET adopted the correct approach, it would inevitably have found that Mr Hakky and the claimant were in materially different circumstances; (d) alternatively, the ET failed to give adequate reasons for its conclusion that Mr Hakky was an appropriate comparator. </span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_51">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">51.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">The claimant submits: (a) the ET did not err in finding that Mr Hakky was an appropriate comparator but carefully considered the circumstances relevant to the comparison; (b) in any event, the claimant’s case was also put on the basis of a hypothetical comparator and, even if Mr Hakky was not in precisely the same circumstances, the ET was entitled to rely on him as a probative comparator; (c) more generally, the ET had assessed the materiality of the investigation and the role this played on the motivation of the first respondent - that was clear from its finding on issue (t); (d) the ET found that the first respondent was advised that there was no reason not to consult with the claimant about the regulatory issue and that it had further failed to afford the claimant the multiple strands of assistance offered to Mr Hakky; (e) as for the claimant not being at work, this was because the respondents (because of his age) had continued to restrict his ability to return and, in contrast to Mr Hakky, failed to encourage and support him in applying for admission to the Register, or to assure him that if he applied he would retain his pay, benefits, status and be considered to be a Consultant in all but name. </span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_52">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">52.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">Finally, in relation to ground (4), the respondents argue: (a) the ET concluded that, prior to December 2019, Mr Vale, Ms Eaton and the second respondent had explored the cost of terminating the claimant’s appointment because of two age-related assumptions; (b) the reason given for this conclusion was that the first respondent had produced “</span>
+                            <span style="font-style:italic;font-size:12pt">no evidence</span>
+                            <span style="font-size:12pt">” to show these steps were taken in respect of other locums, but Ms Eaton’s statement had  exhibited an email setting out the plan to ask all the locums a list of questions, including about retirement, and stated that other locums were asked the same questions; (c) alternatively, the ET had failed to give sufficient reasons for why the evidence of Ms Eaton, Mr Vale, and the second respondent - that they did not make any decisions because of age - was rejected.</span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_53">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">53.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">On this ground of appeal, the claimant argues: (a) as a perversity challenge, this ground faced a high hurdle; (b) there was ample evidence to support the ET’s conclusions in the present case: (i) the ET heard the evidence of Ms Eaton, Mr Vale and the second respondent as to their reasons for exploring termination of the claimant’s employment, which was challenged by the claimant, who gave evidence of the total lack of support of him in the continuance of his employment (as contrasted with the support given to Mr Hakky); (ii) the absence of evidence of steps taken to enquire about the termination of other, younger, doctors’ contracts was only one matter to which the ET had regard, but, in any event, such steps as were taken were very different to those taken to terminate the claimant’s employment; (iii) further, the ET was fully entitled to draw adverse inferences from the wholesale failure of the respondent to produce (or its witnesses to mention in their very detailed written statements) whole swathes of emails between them which were probative of the differential treatment of the claimant and his named comparator.</span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_54">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">54.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">For completeness, I note that no ground of appeal has been pursued relating to the possible issue of justification (section 13(2) </span>
+                            <span style="font-weight:bold;font-size:12pt">EqA </span>
+                            <span style="font-size:12pt">providing that, in the case of age, less favourable treatment on this basis will not amount to unlawful discrimination if it can be shown to be a proportionate means of achieving a legitimate aim). </span>
+                        </p>
+                    </content>
+                </paragraph>
+                <level>
+                    <content>
+                        <p style="text-align:justify;margin-right:0.24in">
+                            <span style="font-weight:bold;font-size:12pt">Liability: The Law</span>
+                        </p>
+                    </content>
+                </level>
+                <paragraph eId="para_55">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.6in;text-indent:-0.5in">55.</num>
+                    <intro>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.6in;margin-right:0.24in">
+                            <span style="font-family:'Times New Roman';font-size:12pt">By section 13 </span>
+                            <span style="font-weight:bold;font-family:'Times New Roman';font-size:12pt">EqA</span>
+                            <span style="font-family:'Times New Roman';font-size:12pt">, it is (relevantly) provided that: </span>
+                        </p>
+                    </intro>
+                    <subparagraph>
+                        <num style="font-size:12pt">“(1)</num>
+                        <content>
+                            <p class="ListParagraph" style="text-align:justify;margin-left:1in;margin-right:0.5in;text-indent:-1in">
+                                <span style="font-size:12pt">A person (A) discriminates against another (B) if, because of a protected characteristic, A treats B less favourably than A treats or would treat others.”</span>
+                            </p>
+                        </content>
+                    </subparagraph>
+                </paragraph>
+                <paragraph eId="para_56">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.6in;text-indent:-0.5in">56.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.6in;margin-right:0.24in">
+                            <span style="font-size:12pt">In carrying out the comparative assessment required by section 13 </span>
+                            <span style="font-weight:bold;font-size:12pt">EqA</span>
+                            <span style="font-size:12pt"> – the requirement that there should be less favourable treatment - the ET must be satisfied that there is no material difference between the circumstances relating to the complainant and any actual or hypothetical comparator (see section 23</span>
+                            <span style="font-weight:bold;font-size:12pt"> EqA</span>
+                            <span style="font-size:12pt">).</span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_57">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.6in;text-indent:-0.5in">57.</num>
+                    <intro>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.6in;margin-right:0.24in">
+                            <span style="font-size:12pt">That said, when constructing a hypothetical comparator, an ET may have regard to the actual cases of those who might not otherwise fully meet the requirements of section 23; a</span>
+                            <span style="font-size:12pt;color:#000000;background-color:#FFFFFF">s was explained by Lord Scott in </span>
+                            <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt;color:#000000;background-color:#FFFFFF">Shamoon v Chief Constable of the Royal Ulster Constabulary</span>
+                            <span style="font-size:12pt;color:#000000;background-color:#FFFFFF">
+                                <ref href="https://caselaw.nationalarchives.gov.uk/ukhl/2003/11" uk:canonical="[2003] UKHL 11" uk:isNeutral="true" uk:origin="TNA" uk:type="case" uk:year="2003">[2003] UKHL 11</ref>; [2003] ICR 285:</span>
+                        </p>
+                    </intro>
+                    <subparagraph>
+                        <num style="font-size:12pt;color:#000000;background-color:#FFFFFF">“110.</num>
+                        <content>
+                            <p class="ListParagraph" style="text-align:justify;margin-left:1in;margin-right:0.5in;text-indent:-1in">
+                                <span style="font-size:12pt;color:#000000;background-color:#FFFFFF">… the comparator required for the purpose of the statutory definition of discrimination must be a comparator in the same position in all material respects of the victim save that he, or she, is not a member of the protected class.  But the comparators that can be of evidential value, sometimes determinative of the case, are not so circumscribed.  Their evidential value will, however, be variable and will inevitably be weakened by material differences between the circumstances relating to them and the circumstances of the victim.”</span>
+                            </p>
+                        </content>
+                    </subparagraph>
+                </paragraph>
+                <paragraph eId="para_58">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">58.</num>
+                    <intro>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">Less favourable treatment in this regard is, however, not simply to be equated with unreasonable treatment; as Lord Rodger observed in </span>
+                            <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt">Shamoon</span>
+                            <span style="font-size:12pt">:</span>
+                        </p>
+                    </intro>
+                    <subparagraph>
+                        <num style="font-size:12pt">“133.</num>
+                        <content>
+                            <p class="ListParagraph" style="text-align:justify;margin-left:1in;margin-right:0.5in;text-indent:-1in">
+                                <span style="font-size:12pt">… circumstances may be relevant even if no reasonable employer would ever have attached any weight to them in considering how to treat his employees.” </span>
+                            </p>
+                        </content>
+                    </subparagraph>
+                </paragraph>
+                <paragraph eId="para_59">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">59.</num>
+                    <intro>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">Whether situations are comparable is a question of fact and degree, </span>
+                            <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt">Hewage v Grampian Health Board</span>
+                            <span style="font-size:12pt"> [2012] UKSC 37; [2012] ICR 1054 SC.  The comparison must, however, be of that which is relevant: there must be “</span>
+                            <span style="font-style:italic;font-size:12pt">a sufficient link in logic</span>
+                            <span style="font-size:12pt">” between the two cases, </span>
+                            <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt">Kalu v Brighton &amp; Sussex University Hospitals NHS Trust &amp; Ors</span>
+                            <span style="font-size:12pt"> UKEAT/0609/12 at paragraph 24.  All that said, it will sometimes not be possible to disentangle the issue of less favourable treatment from the question why that treatment occurred; as Lord Nicolls observed in </span>
+                            <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt">Shamoon</span>
+                            <span style="font-size:12pt">:</span>
+                        </p>
+                    </intro>
+                    <subparagraph>
+                        <num style="font-size:12pt">“8.</num>
+                        <content>
+                            <p class="ListParagraph" style="text-align:justify;margin-left:1in;margin-right:0.5in;text-indent:-1in">
+                                <span style="font-size:12pt">… Sometimes the less favourable treatment issue cannot be resolved without, at the same time, deciding the reason-why issue. The two issues are intertwined.”</span>
+                            </p>
+                        </content>
+                    </subparagraph>
+                    <subparagraph>
+                        <content>
+                            <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                                <span style="font-size:12pt">And see, to similar effect, </span>
+                                <span style="font-style:italic;font-size:12pt">per</span>
+                                <span style="font-size:12pt"> Lord Rodger at paragraph 125. </span>
+                            </p>
+                        </content>
+                    </subparagraph>
+                </paragraph>
+                <paragraph eId="para_60">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">60.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">Key to a claim of direct discrimination will, therefore, generally be the determination of the reason for the treatment in issue: whether it was “</span>
+                            <span style="font-style:italic;font-size:12pt">because of</span>
+                            <span style="font-size:12pt">” the relevant protected characteristic.  In some cases, the reason for the treatment will be inherent in the conduct itself.  Thus, in </span>
+                            <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt">James v Eastleigh Borough Council</span>
+                            <span style="font-size:12pt">
+                                <ref href="#" uk:canonical="[1990] ICR 554" uk:isNeutral="false" uk:origin="TNA" uk:type="case" uk:year="1990">[1990] ICR 554</ref> HL, the complaint related to the application of a criterion (pensionable age) that was necessarily discriminatory (a man aged 60-64 would be excluded from a benefit open to women from age 60).  In other cases, however, it is necessary to look into the mental processes of the putative discriminator to determine whether or not the protected characteristic was in fact the reason for the treatment (and see the discussion in this regard in </span>
+                            <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt">Amnesty International v Ahmed </span>
+                            <span style="font-size:12pt">
+                                <ref href="#" uk:canonical="[2009] ICR 1450" uk:isNeutral="false" uk:origin="TNA" uk:type="case" uk:year="2009">[2009] ICR 1450</ref> EAT).  As the ET identified (see paragraph 162, liability judgment), the relevant protected characteristic need not, however, have been the only reason for the treatment in question; it will be sufficient if it is the “</span>
+                            <span style="font-style:italic;font-size:12pt">effective and predominant cause</span>
+                            <span style="font-size:12pt">” or the “</span>
+                            <span style="font-style:italic;font-size:12pt">real or efficient cause</span>
+                            <span style="font-size:12pt">”, see </span>
+                            <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt">O’Neill v Governors of St Thomas More RC Voluntarily Aided Upper School and anor</span>
+                            <span style="font-size:12pt">
+                                <ref href="#" uk:canonical="[1997] ICR 33" uk:isNeutral="false" uk:origin="TNA" uk:type="case" uk:year="1997">[1997] ICR 33</ref>.
+                            </span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_61">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">61.</num>
+                    <intro>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">In determining claims under the </span>
+                            <span style="font-weight:bold;font-size:12pt">EqA</span>
+                            <span style="font-size:12pt">, the burden of proof operates as provided by section 136:</span>
+                        </p>
+                    </intro>
+                    <subparagraph>
+                        <content>
+                            <p class="NormalWeb" style="text-align:justify;margin-left:1in;margin-right:0.5in">
+                                <span style="font-family:'Times New Roman';font-size:11pt;color:#000000">“(2)     If there are facts from which the court could decide, in the absence of any other explanation, that a person (A) contravened the provision concerned, the court must hold that the contravention occurred.</span>
+                            </p>
+                        </content>
+                    </subparagraph>
+                    <subparagraph>
+                        <content>
+                            <p class="NormalWeb" style="text-align:justify;margin-left:1in;margin-right:0.5in">
+                                <span style="font-family:'Times New Roman';font-size:11pt;color:#000000">(3)     But subsection (2) does not apply if A shows that A did not contravene the provision.</span>
+                            </p>
+                        </content>
+                    </subparagraph>
+                    <subparagraph>
+                        <content>
+                            <p class="NormalWeb" style="text-align:justify;margin-left:1in;margin-right:0.5in">
+                                <span style="font-family:'Times New Roman';font-size:11pt;color:#000000">…”</span>
+                            </p>
+                        </content>
+                    </subparagraph>
+                </paragraph>
+                <paragraph eId="para_62">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">62.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">The approach to be adopted in applying section 136 is as laid down in </span>
+                            <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt;color:#000000;background-color:#FFFFFF">Igen Ltd v Wong; Chamberlin Solicitors v Emokpae; Brunel University v Webster</span>
+                            <span style="font-size:12pt;color:#000000;background-color:#FFFFFF">
+                                <ref href="https://caselaw.nationalarchives.gov.uk/id/ewca/civ/2005/142" uk:canonical="[2005] EWCA Civ 142" uk:isNeutral="true" uk:origin="TNA" uk:type="case" uk:year="2005">[2005] EWCA Civ 142</ref>,                                <ref href="#" uk:canonical="[2005] ICR 931" uk:isNeutral="false" uk:origin="TNA" uk:type="case" uk:year="2005">[2005] ICR 931</ref> (largely endorsing the principles set out in </span>
+                            <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt;color:#000000;background-color:#FFFFFF">Barton v Investec Securities Ltd</span>
+                            <span style="font-size:12pt;color:#000000;background-color:#FFFFFF">
+                                <ref href="#" uk:canonical="[2003] ICR 1205" uk:isNeutral="false" uk:origin="TNA" uk:type="case" uk:year="2003">[2003] ICR 1205</ref> EAT), approved by the Supreme Court in </span>
+                            <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt;color:#000000;background-color:#FFFFFF">Hewage</span>
+                            <span style="font-size:12pt;color:#000000;background-color:#FFFFFF"> and in </span>
+                            <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt;color:#000000;background-color:#FFFFFF">Efobi v Royal Mail Group Ltd</span>
+                            <span style="font-size:12pt;color:#000000;background-color:#FFFFFF">
+                                <ref href="https://caselaw.nationalarchives.gov.uk/uksc/2021/33" uk:canonical="[2021] UKSC 33" uk:isNeutral="true" uk:origin="TNA" uk:type="case" uk:year="2021">[2021] UKSC 33</ref>
+                            </span>
+                            <span style="font-style:italic;font-size:12pt;color:#000000;background-color:#FFFFFF">.  </span>
+                            <span style="font-size:12pt;color:#000000;background-color:#FFFFFF">In short, to the extent that the ET is satisfied (on a balance of probabilities) that the claimant has established facts from which it </span>
+                            <span style="font-style:italic;font-size:12pt;color:#000000;background-color:#FFFFFF">could</span>
+                            <span style="font-size:12pt;color:#000000;background-color:#FFFFFF">, in the absence of an adequate explanation, conclude that the respondent had committed an act of unlawful discrimination (having regard to </span>
+                            <span style="font-style:italic;font-size:12pt;color:#000000;background-color:#FFFFFF">all</span>
+                            <span style="font-size:12pt;color:#000000;background-color:#FFFFFF"> the evidence, and drawing such inferences as are legitimate from its primary findings of fact at that preliminary stage), it will be for the respondent to prove (again, on the balance of probabilities) that the treatment was in no sense whatsoever because of the relevant protected characteristic.  In discharging this burden, a respondent would normally be expected to adduce </span>
+                            <span style="font-style:italic;font-size:12pt;color:#000000;background-color:#FFFFFF">cogent evidence </span>
+                            <span style="font-size:12pt;color:#000000;background-color:#FFFFFF">that the relevant protected characteristic was not the reason for the treatment in question.  Although section 136 </span>
+                            <span style="font-weight:bold;font-size:12pt;color:#000000;background-color:#FFFFFF">EqA</span>
+                            <span style="font-size:12pt;color:#000000;background-color:#FFFFFF"> can thus be seen to give rise to a two-staged approach, this does not, however, have to be applied in a formulaic manner, see </span>
+                            <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt;color:#000000;background-color:#FFFFFF">Laing v Manchester City Council</span>
+                            <span style="font-size:12pt;color:#000000;background-color:#FFFFFF">
+                                <ref href="#" uk:canonical="[2006] ICR 1519" uk:isNeutral="false" uk:origin="TNA" uk:type="case" uk:year="2006">[2006] ICR 1519</ref>, and, in considering whether the claimant has established a </span>
+                            <span style="font-style:italic;font-size:12pt;color:#000000;background-color:#FFFFFF">prima facie</span>
+                            <span style="font-size:12pt;color:#000000;background-color:#FFFFFF"> case of discrimination, an ET must have regard to </span>
+                            <span style="font-style:italic;font-size:12pt;color:#000000;background-color:#FFFFFF">all </span>
+                            <span style="font-size:12pt;color:#000000;background-color:#FFFFFF">the evidence, not just that adduced by the claimant (</span>
+                            <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt;color:#000000;background-color:#FFFFFF">Efobi</span>
+                            <span style="font-size:12pt;color:#000000;background-color:#FFFFFF">).</span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_63">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">63.</num>
+                    <intro>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">Having considered the tests the ET was required to apply in determining the issues before it, it is right that I remind myself of the approach I am required to adopt at this appellate stage.  The guidance in this regard was helpfully distilled by Popplewell LJ at paragraph 57 </span>
+                            <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt">DPP Law Ltd v Greenberg</span>
+                            <span style="font-size:12pt"> [2021] EWCA Civ 672.  In particular, I bear in mind the need to read the ET’s decision fairly and as a whole, bearing in mind that it is not required to identify all the evidence relied on in reaching its conclusions of fact and should not be assumed to have disregarded evidence merely because it did not expressly refer to it (</span>
+                            <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt">RSPB v Croucher</span>
+                            <span style="font-size:12pt"> [1984] ICR 604, 609-610).  Similarly, where an ET has correctly stated the relevant legal principles, an appellate tribunal should be slow to conclude:</span>
+                        </p>
+                    </intro>
+                    <subparagraph>
+                        <content>
+                            <p class="ListParagraph" style="text-align:justify;margin-left:1in;margin-right:0.5in">
+                                <span style="font-size:12pt">“… that it has not applied those principles, and should generally do so only where it is clear from the language used that a different principle has been applied to the facts found. …” paragraph 58 </span>
+                                <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt">DPP Law v Greenberg</span>
+                            </p>
+                        </content>
+                    </subparagraph>
+                </paragraph>
+                <paragraph eId="para_64">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">64.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">Finally, I remind myself that where an appeal is pursued on the ground of perversity it will only succeed where “</span>
+                            <span style="font-style:italic;font-size:12pt">an overwhelming case”</span>
+                            <span style="font-size:12pt"> is made out that the ET reached a decision which no reasonable tribunal, on a proper appreciation of the evidence and the law, would have reached; </span>
+                            <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt">Yeboah v Crofton</span>
+                            <span style="font-size:12pt">
+                                <ref href="https://caselaw.nationalarchives.gov.uk/id/ewca/civ/2002/794" uk:canonical="[2002] EWCA Civ 794" uk:isNeutral="true" uk:origin="TNA" uk:type="case" uk:year="2002">[2002] EWCA Civ 794</ref>,                                <ref href="#" uk:canonical="[2002] IRLR 634" uk:isNeutral="false" uk:origin="TNA" uk:type="case" uk:year="2002">[2002] IRLR 634</ref>.
+                            </span>
+                        </p>
+                    </content>
+                </paragraph>
+                <level>
+                    <content>
+                        <p style="text-align:justify;margin-right:0.24in">
+                            <span style="font-weight:bold;font-size:12pt">The Liability Appeal: Discussion and Conclusions</span>
+                        </p>
+                    </content>
+                </level>
+                <paragraph eId="para_65">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">65.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">In seeking to challenge the ET’s conclusion on liability in respect of the section 13, direct age discrimination claim, the respondents attack various aspects of the reasoning summarised at paragraph 197 of the ET’s liability judgment.  Bearing in mind the approach I am required to adopt (see </span>
+                            <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt">DPP Law v Greenberg</span>
+                            <span style="font-size:12pt">, </span>
+                            <span style="font-style:italic;font-size:12pt">supra</span>
+                            <span style="font-size:12pt">), I have considered each of the objections raised before stepping back to see whether – taking the reasoning as a whole – these can be said to render the ET’s conclusion unsafe. </span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_66">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">66.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">Considering first the criticisms made in respect of the comparison of the claimant’s case with that of Mr Hakky (ground (3)), the ET found that the second respondent had taken an active part in encouraging, supporting and advocating for Mr Hakky and that both respondents had supported him to remain in post notwithstanding the regulatory issue.  Specifically (and adopting the ET’s own summary of its conclusions, at paragraph 99 of the liability judgment): (a) Mr Hakky had been consulted in relation to the regulatory issue from September 2017, (b) he was told he would continue to be seen by his colleagues as a Consultant with the same role and responsibilities, (c) he was told that steps would be taken to mitigate the reduction to his pay, (d) he was supported in retaining the same duties before it was agreed that his Locum Consultant contract would be extended, (e) he was encouraged and supported to make an application to join the Register, (f) he was retained in the same role and on the same pay pending his specialist registration more than three years after the regulatory issue had been identified.</span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_67">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">67.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">On each of these points, the ET found that the claimant had not received the favourable treatment meted out to Mr Hakky.  That, it considered, was relevant to the determination of the reason for the treatment complained of by the claimant (see paragraph 197(1), liability judgment).  The respondents object that the ET thereby lost sight of the different circumstances of the two cases: specifically, the regulatory issue was identified at a point in time when the claimant’s clinical competence was under investigation and his practice was restricted.  Although the ET found that, in October 2017, Ms Eaton had advised that there was no need to delay consulting the claimant about the regulatory issue, it had also accepted the explanations given by the second respondent and Mr Vale for nevertheless deciding not to discuss this with him at that stage: given the on-going investigation and continuing restriction, unlike Mr Hakky, there was no immediate imperative for the regulatory issue to be raised with the claimant as he was not undertaking clinical duties and it was therefore unnecessary to discuss with him the need for supervision (paragraphs 87, 89 and 90, liability judgment).</span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_68">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">68.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">Considering the position up to late December 2017/early January 2018, I agree with the respondents.  Although (given Ms Eaton’s advice) the ET might have considered the respondents’ position unreasonable, that was not the relevant question.  In determining whether the claimant’s circumstances (other than the difference of age) were comparable to those of Mr Hakky, it was a material point of distinction that the respondents had seen the continuing investigation and practice restriction as relevant, even if, objectively speaking, another (more reasonable) employer would not have taken the same view (see </span>
+                            <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt">Shamoon</span>
+                            <span style="font-size:12pt">, paragraph 133).  To the extent, therefore, that the ET found that a comparison with Mr Hakky’s case established that the claimant was treated less favourably in the period between May to December 2017, and that this established a </span>
+                            <span style="font-style:italic;font-size:12pt">prima facie</span>
+                            <span style="font-size:12pt"> case for the purposes of section 136 </span>
+                            <span style="font-weight:bold;font-size:12pt">EqA</span>
+                            <span style="font-size:12pt">, the ET erred in its approach and failed to take into account the explanation it had itself found for the claimant’s treatment during this period (see paragraphs 87 and 90, liability judgment).  That, it seems to me, is an error that fatally undermines the ET’s finding on issue (ee); it is not, however, determinative of the remaining issues. </span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_69">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">69.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">As the ET found, the position changed during December 2017 and into 2018.  Although there were still differences between the claimant’s circumstances and those of Mr Hakky, on the ET’s findings, these were no longer material.  The issue of the (potential) disciplinary process had to be resolved, but there was no longer any clinical reason for his continued restriction from practice (paragraph 103, ET liability judgment).  Thereafter, on the ET’s findings of fact, it was not the investigation (or the potential disciplinary hearing) that impacted upon the claimant’s ability to return to work, rather it was the respondents’ response to the regulatory issue in his case (see, for example, the ET at paragraphs 114 and 127, liability judgment and note its findings on issues (n), (t) and (x)).  That, however, was the same issue that arose in respect of Mr Hakky: both were Locum Consultants who had been employed for more than 12 months without being on the Register and the respondents thus faced the same dilemma in determining how to handle this situation. </span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_70">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">70.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">The respondents suggest that a further material difference arose, in that – in contrast to the claimant - they had no doubt as to Mr Hakky’s willingness to apply to join the Register.  Comparing like with like, however, that objection does not withstand the ET’s findings of fact.  From the respondents’ perspective, both Mr Hakky and the claimant had been employed for some time without being entered on the Register.  When the regulatory issue was first raised with Mr Hakky, however, the ET found that the questions being asked internally related to his moving on to the Register, and that he had been reassured that he would be supported in his application and that, in the meantime, he would continue to be treated “</span>
+                            <span style="font-style:italic;font-size:12pt">as a consultant colleague</span>
+                            <span style="font-size:12pt">” and not suffer financial disadvantage (paragraphs 87-95, liability judgment).  In contrast, in the autumn of 2017, the respondents proactively investigated the costs of terminating the claimant’s employment (paragraph 84, liability judgment) and, when the regulatory issue was first raised with the claimant in December 2017 and January 2018, he was not invited to make an application for specialist registration but was told he would be moved to the more junior role of Speciality Doctor, working to a revised job plan, without the same autonomy (paragraphs 109-110, liability judgment). </span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_71">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">71.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">Considering the </span>
+                            <span style="font-style:italic;font-size:12pt">relevant</span>
+                            <span style="font-size:12pt"> circumstances of the claimant and Mr Hakky (whether taken as a direct comparator or as probative of a hypothetical comparison), as understood by the respondents at the time, the ET found that the facts were such that it could conclude that the claimant had suffered unlawful direct age discrimination.  Thus, although advised by Ms Eaton that the claimant could return to his Consultant duties until his contract expired (see, for example, paragraphs 127 and 131 liability judgment), the respondents did not communicate that to the claimant but, on the contrary, further extended his restriction.  That, as the ET found, stood in obvious contrast to the very positive steps taken to reassure Mr Hakky of the arrangements that had been put in place to enable him to continue with his Consultant duties notwithstanding the on-going regulatory issue.  Similarly, when communicating with the claimant about his return to work, the ET found there was a reluctance to engage with him or to take the necessary steps to enable him to retain his autonomy and status (see, for example, paragraphs 130, 131, 133-135, liability judgment).  Again, the ET permissibly found this was very different to the way in which the respondents had engaged with Mr Hakky. </span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_72">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">72.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">From December 2017/January 2018, given this marked difference in the treatment of the claimant and Mr Hakky at a time when, on the ET’s findings of fact, their circumstances were no longer </span>
+                            <span style="font-style:italic;font-size:12pt">materially </span>
+                            <span style="font-size:12pt">different, I cannot see that a valid objection can be taken to the ET’s conclusion (on issues (ff) to (jj)) that the claimant suffered less favourable treatment or to its finding (more generally) that this went to the establishment of a </span>
+                            <span style="font-style:italic;font-size:12pt">prima facie</span>
+                            <span style="font-size:12pt"> case of unlawful age discrimination. </span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_73">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">73.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">The respondents raise an additional, and somewhat separate, objection to the ET’s finding (issue (y)) that the claimant’s return to work was obstructed and there was a failure to conduct his annual appraisal.  It is said that Mr Hakky could not be a relevant comparator as he had not been away from work and had not faced the same difficulty as the claimant in relation to the carrying out of an appraisal while on restricted practice. </span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_74">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">74.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">The difficulty with these criticisms is that they fail to properly engage with the ET’s findings.  As the ET found (and contrary to the suggestion made in the respondents’ skeleton argument), it had been agreed that Mr Hakky would continue in his Locum Consultant post </span>
+                            <span style="font-style:italic;font-size:12pt">before</span>
+                            <span style="font-size:12pt"> the start date for the Speciality Doctor contract (paragraph 139, liability judgment).  More than that, however, the ET was clear that Mr Hakky’s status and continued ability to work autonomously, and without financial detriment, had been assured by the respondents throughout (see the findings at paragraphs 87-99, liability judgment).  Similar assurances had not been given to the claimant, notwithstanding the respondents’ awareness that, from December 2017/January 2018, there was no reason why he too should not be at work, continuing to carry out his former duties (paragraphs 109-112, 114, 127-131, and 134-135 liability judgment).  As for the claimant’s appraisal, the ET found this resulted from the same lack of support.  Although there had been no continuing justification for the claimant’s restriction from practice during 2018, by 26 April 2018 this had still not been undertaken (paragraph 132, liability judgment).  The ET permissibly considered this illustrative of the respondents’ failure to preserve the claimant’s role and to provide a similar level of support to that provided to Mr Hakky.  On this point, even if Mr Hakky’s position was not precisely on all fours with that of the claimant, the ET was entitled to see his case as probative of how the respondents might otherwise have behaved. </span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_75">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">75.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">The respondents further contend (by ground (4)) that it was perverse for the ET to conclude (paragraph 84, liability judgment) that no steps had been taken to explore the costs of terminating the employment of Locum Consultants </span>
+                            <span style="font-style:italic;font-size:12pt">other than</span>
+                            <span style="font-size:12pt"> the claimant, when this had been proposed by Ms Eaton as part of a general review and when her statement had addressed this and had exhibited an email setting out a plan to raise the issue of retirement (amongst other things) with all the Locum Consultants.  </span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_76">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">76.</num>
+                    <intro>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">It is, however, apparent that the ET was aware of this evidence.  Specifically, at paragraph 69, it referred to the proposed general review, which had identified one of the relevant considerations as being: </span>
+                        </p>
+                    </intro>
+                    <subparagraph>
+                        <content>
+                            <p class="ListParagraph" style="text-align:justify;margin-left:1in;margin-right:0.5in">
+                                <span style="font-size:12pt">“The age of the locum and, if near retirement age, to consider early retirement in the interests of efficiency of the service.”</span>
+                            </p>
+                        </content>
+                    </subparagraph>
+                    <subparagraph>
+                        <intro>
+                            <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                                <span style="font-size:12pt">Ms Eaton’s statement had further addressed this issue, explaining:</span>
+                            </p>
+                        </intro>
+                        <subparagraph>
+                            <num style="font-size:12pt">“26.</num>
+                            <content>
+                                <p class="ListParagraph" style="text-align:justify;margin-left:1in;margin-right:0.5in;text-indent:-1in">
+                                    <span style="font-size:12pt">Another option informally explored for affected locum consultants was retirement on the grounds of efficiency.  As the Claimant had commonly shared of his intention to retire when he reached 60 years in 2019, early retirement was explored….”</span>
+                                </p>
+                            </content>
+                        </subparagraph>
+                    </subparagraph>
+                </paragraph>
+                <paragraph eId="para_77">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">77.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">The ET accepted that the exploration of this option in the claimant’s case did not demonstrate a predetermination on the respondents’ part to terminate his employment.  It did, however, consider it relevant that there was no evidence of such a step actually being taken in relation to any of the other Locum Consultants affected by the regulatory issue.  The ET’s conclusion in this regard cannot be said to be perverse, rather it was entirely consistent with the evidence.  Ms Eaton’s proposed review identified early retirement as a matter for further consideration if the Locum Consultant was “</span>
+                            <span style="font-style:italic;font-size:12pt">near retirement age</span>
+                            <span style="font-size:12pt">”.  Her witness statement confirmed that this had been explored in the claimant’s case, because his age and intention to retire in 2019 was well known, but said nothing about any similar exercise actually being undertaken in any other case.  Although acknowledged by the ET to be of limited evidential weight, it was entitled to consider that this provided some insight into how the claimant’s case was viewed as compared to that of others, who were in the same position but who were not of a similar age. </span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_78">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">78.</num>
+                    <intro>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">The respondents’ objection to the ET’s finding as to a “</span>
+                            <span style="font-style:italic;font-size:12pt">lack of cogent explanation</span>
+                            <span style="font-size:12pt">” (ground (2)) has to be seen in the light of its findings on comparative treatment: as it explained, it found that:</span>
+                        </p>
+                    </intro>
+                    <subparagraph>
+                        <num style="font-size:12pt">“197.</num>
+                        <content>
+                            <p class="ListParagraph" style="text-align:justify;margin-left:1in;margin-right:0.5in;text-indent:-1in">
+                                <span style="font-size:12pt">… the claimant has established a prima facie case and the respondents have failed to show that this treatment was in no sense whatsoever because of his age, due to the following: … (3) The lack of a cogent explanation for this disparate treatment.”</span>
+                            </p>
+                        </content>
+                    </subparagraph>
+                </paragraph>
+                <paragraph eId="para_79">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">79.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">The ET was thus appropriately applying the burden of proof: having found that there was a relevant difference of treatment that required explanation, the ET was entitled to look to the respondents for </span>
+                            <span style="font-style:italic;font-size:12pt">cogent </span>
+                            <span style="font-size:12pt">evidence that this was not because of age (see </span>
+                            <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt">Igen</span>
+                            <span style="font-size:12pt">).  Although the respondents have identified an error on the ET’s part when considering the explanation provided for the treatment of the claimant prior to December 2017 (see the discussion at paragraph 68 above), the reason provided at that earlier stage (the on-going investigation and the justified practice restriction) no longer applied thereafter.  Once the earlier justifications for not consulting with the claimant about the regulatory issue had ceased to apply, given its findings as to the difference in the claimant’s treatment as compared to Mr Hakky, the ET was entitled to look to see what cogent evidence there was to demonstrate that this was for a reason other than age. </span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_80">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">80.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">For the respondents, it is again objected that there were reasons put forward that demonstrated why the claimant’s case continued to be seen differently to that of others (in particular, Mr Hakky).  As previously discussed, however, those reasons did not withstand scrutiny by the ET.  Thus, it did not accept that the question of early retirement was considered in other cases because there was no evidence that this was done.  Early retirement was, however, something proactively explored in the claimant’s case - even before the regulatory issue had been raised with him - because of his age and his stated intention to retire at 60, and because it was considered he would not be prepared to accept a more junior role (albeit this last consideration also applied to others).  Equally, the ET did not accept that the claimant’s continued practice restriction was a reason for the difference in treatment, because it found that the only reason for the failure to return the claimant to his duties arose from the respondents’ response to the regulatory issue in his case.  The ET did not accept that this was explained by the claimant’s reluctance to apply for specialist registration, because the respondents had never invited him to apply and had simply never approached the issue in the same (very supportive) way they had with others, such as Mr Hakky. </span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_81">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">81.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">Furthermore, as well as considering the claimant’s treatment on a comparative basis, the ET also took into account the evidence provided by the respondents as to why they had responded to him in the way that they did.  Although initially required to ask itself whether the claimant had established a </span>
+                            <span style="font-style:italic;font-size:12pt">prima facie</span>
+                            <span style="font-size:12pt"> case of unlawful age discrimination, the ET thus appropriately had regard to </span>
+                            <span style="font-style:italic;font-size:12pt">all</span>
+                            <span style="font-size:12pt"> the evidence, which included the evidence of the respondents as to the factors to which they had had regard at the time (see </span>
+                            <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt">Efobi</span>
+                            <span style="font-size:12pt">).  The ET was thus entitled to take into account the evidence adduced by the respondents for the claimant’s treatment, which included the express link to age identified in Ms Eaton’s proposed review (see above) and Mr Vale’s evidence that the option of early retirement was considered in the claimant’s case because “</span>
+                            <span style="font-style:italic;font-size:12pt">he was aware of the claimant’s age, [and] it was felt that it would be difficult for the claimant to revert to a more junior role</span>
+                            <span style="font-size:12pt">” (paragraph 84, liability judgment).  The ET was also entitled to find that the failure to invite the claimant to make an application for registration was founded upon an assumption that he was “</span>
+                            <span style="font-style:italic;font-size:12pt">neither interested nor willing in proceeding with such an application</span>
+                            <span style="font-size:12pt">” because Mr Vale and Ms Eaton were “</span>
+                            <span style="font-style:italic;font-size:12pt">cognisant of the claimant’s intention to retire</span>
+                            <span style="font-size:12pt">” and because he had “</span>
+                            <span style="font-style:italic;font-size:12pt">conveyed his intention to remain working in an autonomous capacity until his 60</span>
+                            <span style="font-style:italic;vertical-align:super;font-size:12pt">th</span>
+                            <span style="font-style:italic;font-size:12pt"> birthday by means which did not involve him applying to join the Register</span>
+                            <span style="font-size:12pt">” (paragraph 110, liability judgment).</span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_82">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">82.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">Addressing the ET’s findings on these points, the respondents object (ground (1)) that it applied the wrong test: holding that “</span>
+                            <span style="font-style:italic;font-size:12pt">age-related”</span>
+                            <span style="font-size:12pt"> assumptions could provide a basis for upholding the claimant’s section 13 complaint, rather than asking whether the treatment in question had been “</span>
+                            <span style="font-style:italic;font-size:12pt">because of</span>
+                            <span style="font-size:12pt">” age.  I do not, however, consider this to be a fair characterisation of the ET’s reasoning.  Considering the evidence in the round (as it was required to do), the ET had found that the claimant had established a </span>
+                            <span style="font-style:italic;font-size:12pt">prima facie</span>
+                            <span style="font-size:12pt"> case of age discrimination.  The question was then whether the respondents had provided cogent evidence of an explanation that was “</span>
+                            <span style="font-style:italic;font-size:12pt">in no sense whatsoever</span>
+                            <span style="font-size:12pt">” (per </span>
+                            <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt">Igen</span>
+                            <span style="font-size:12pt">) because of age.  The fact that the reason for the respondents’ treatment of the claimant (as found by the ET) was “</span>
+                            <span style="font-style:italic;font-size:12pt">age-related</span>
+                            <span style="font-size:12pt">” explained the ET’s conclusion that the respondents had failed to discharge their burden of proof.  The ET had correctly directed itself as to the relevant legal test under section 13 </span>
+                            <span style="font-weight:bold;font-size:12pt">EqA</span>
+                            <span style="font-size:12pt"> at paragraphs 8.9 and 162.  There is no basis for inferring that it lost sight of that test in its application of the burden of proof at paragraph 197. </span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_83">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">83.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">More than that, however, it is apparent that the ET did not treat this as a </span>
+                            <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt">James v Eastleigh</span>
+                            <span style="font-size:12pt"> type of case, assuming that a difficulty in moving to a more junior role and/or an intention to retire early must be taken to stand as a proxy for age.  Rather, it found that these were age-related assumptions that the respondents had made.  The fact that the claimant had expressed his intention to retire in the near future did not automatically mean that he would not wish to be supported in applying for specialist registration, and it was clear that neither Mr Hakky nor the claimant wished to move to a supervised role, when they had been acting as Locum Consultants for so many years.  In Mr Hakky’s case, however, the respondents assumed he could (and should) be supported in applying for entry onto the Register; in the claimant’s case it was assumed he would be neither interested nor willing to do so (paragraph 110, liability judgment).  In the circumstances, the ET was entitled to find that these were assumptions that in fact related to the claimant’s age. </span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_84">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">84.</num>
+                    <intro>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">For completeness at this point, I observe that it might be objected that the ET ultimately found that the respondents’ assumptions were not entirely without justification.  Certainly, in reaching its decision on remedy, the ET concluded:</span>
+                        </p>
+                    </intro>
+                    <subparagraph>
+                        <num style="font-size:12pt">“36.</num>
+                        <content>
+                            <p class="ListParagraph" style="text-align:justify;margin-left:1in;margin-right:0.5in;text-indent:-1in">
+                                <span style="font-size:12pt">We therefore find it unlikely that, given his intention to retire at 60 and his projected pension benefits, the length of time it would have taken him to complete an application to join the Register, and the claimant’s animus towards the second respondent in particular which related to conduct which we did not find to be discriminatory, that had he been treated in the same way as Mr Hakky in relation to the regulatory issue in October 2017, returned to his locum consultant role in January 2018 and been supported with an appraisal, that he would have applied to join the Register.”</span>
+                            </p>
+                        </content>
+                    </subparagraph>
+                    <subparagraph>
+                        <content>
+                            <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                                <span style="font-size:12pt">The fact, however, that the respondents’ assumptions might ultimately have been born out does not undermine the ET’s finding that the claimant had suffered unlawful discrimination as a result of being treated less favourably because of age (and whether or not such treatment might have been justified in this context is not a point that has been argued on this appeal). </span>
+                            </p>
+                        </content>
+                    </subparagraph>
+                </paragraph>
+                <paragraph eId="para_85">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">85.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">Standing back and considering the ET’s judgment as a whole, other than the mistake I have found to have been made in respect of the period prior to December 2017, I am not persuaded that the respondents have identified any error of principle or approach such as would render the ET’s conclusions unsafe, nor do I consider that it can be complained that the ET failed to adequately explain its reasoning.  As the claimant has observed, the specific objections raised by the grounds of appeal relate to only some of the reasons provided by the ET for its decision on the section 13 claim (see paragraph 197, liability judgment).  Properly engaging with the ET’s findings of fact, for the reasons I have explained, I cannot see that the respondents’ objections are made out.  Taken along with the other factors relied on by the ET, the decision reached was one that was permissible on the evidence and findings of fact in this case.  Properly understood, the liability appeal is an attempt to re-run the respondents’ case below and to seek to persuade this appellate tribunal to take a different view of the facts to that reached by the ET.  That, however, is not the role of the EAT and the liability appeal is therefore dismissed. </span>
+                        </p>
+                    </content>
+                </paragraph>
+                <level>
+                    <content>
+                        <p style="text-align:justify;margin-right:0.24in">
+                            <span style="font-weight:bold;font-size:12pt">Remedy: The Grounds of Appeal and the Parties’ Submissions</span>
+                        </p>
+                    </content>
+                </level>
+                <paragraph eId="para_86">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">86.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">The respondents’ appeal against the ET’s remedy judgment is put on solely one ground, that the ET erred in law in awarding compensation based on a finding that the claimant would have continued in employment as a Locum Consultant when that would have been unlawful under the </span>
+                            <span style="font-weight:bold;font-size:12pt">1996 Regulations</span>
+                            <span style="font-size:12pt">. </span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_87">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">87.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">The respondents argue that, if a contract is prohibited by legislation, a party who cannot sue on that unenforceable contract should not be permitted to obtain the same relief by bringing a claim for restitution (</span>
+                            <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt">Mohamed v Alaga &amp; Co</span>
+                            <span style="font-size:12pt">
+                                <ref href="#" uk:canonical="[2000] 1 WLR 1815" uk:isNeutral="false" uk:origin="TNA" uk:type="case" uk:year="2000">[2000] 1 WLR 1815</ref>, per Bingham CJ at 1824G-1825A and Walker LJ at 1826G-1827A).  Although the court may make an award of restitution and/or quantum meruit in respect of work already performed under an ultra vires contract (</span>
+                            <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt">Mohamed</span>
+                            <span style="font-size:12pt"> per Bingham CJ at 1825H), that would not alter the duty of the court to prevent, and not reward, unlawful conduct (see the observations of Rix LJ in </span>
+                            <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt">Eastbourne Borough Council v Foster</span>
+                            <span style="font-size:12pt">
+                                <ref href="#" uk:canonical="[2002] ICR 234" uk:isNeutral="false" uk:origin="TNA" uk:type="case" uk:year="2002">[2002] ICR 234</ref>, at paragraph 35).  Where work has not already been performed, any award of compensation must be based upon an assumption that the parties will act lawfully: an ET should, therefore, not award compensation for a period during which the claimant could not lawfully have worked, </span>
+                            <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt">Kings Castle Church v Okukusie</span>
+                            <span style="font-size:12pt"> UKEAT/0472/11 at paragraph 22. </span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_88">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">88.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">It is the respondents’ case that, however unattractive it might seem, the only compensation that the claimant could receive in respect of the discrimination he had suffered would be an award for injury to feelings. </span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_89">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">89.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">For the claimant, it is said that this appeal is premised on an inaccurate characterisation of the ET’s finding: the ET did not award compensation for the lost chance of performing an unlawful contract but had made an award based on a measure of damages assessed on the basis that, but for the unlawful discrimination the ET had found, the first respondent would have continued to employ the claimant until the age of 60.  This was, further, a correct application of the principle set out by the Court of Appeal in </span>
+                            <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt">Hall v Woolston Hall Leisure Ltd</span>
+                            <span style="font-size:12pt">
+                                <ref href="#" uk:canonical="[2001] ICR 99" uk:isNeutral="false" uk:origin="TNA" uk:type="case" uk:year="2001">[2001] ICR 99</ref>, that where an employee was subjected to unlawful discrimination, the fact that the contract of employment was (with the employer’s knowledge) tainted by illegality would not be a bar to the employee’s compensation. </span>
+                        </p>
+                    </content>
+                </paragraph>
+                <level>
+                    <content>
+                        <p style="text-align:justify;margin-right:0.24in">
+                            <span style="font-weight:bold;font-size:12pt">Remedy: The Relevant Legal Principles</span>
+                        </p>
+                    </content>
+                </level>
+                <paragraph eId="para_90">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">90.</num>
+                    <intro>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">No issue is taken as to the ET’s recitation of the general legal principles relevant to the assessment of compensation for pecuniary losses, set out at paragraphs 2-6 of the remedy judgment, as follows:</span>
+                        </p>
+                    </intro>
+                    <subparagraph>
+                        <num style="font-size:12pt">“2.</num>
+                        <content>
+                            <p class="ListParagraph" style="text-align:justify;margin-left:1in;margin-right:0.5in;text-indent:-1in">
+                                <span style="font-size:12pt">Where, such as in this case, the claimant’s dismissal has been found to be both unfair and discriminatory, the compensatory award should be made by the tribunal under the discrimination legislation (see </span>
+                                <span style="font-style:italic;font-size:12pt">D’Souza v London Borough of Lambeth</span>
+                                <span style="font-size:12pt">
+                                    <ref href="#" uk:canonical="[1997] IRLR 677" uk:isNeutral="false" uk:origin="TNA" uk:type="case" uk:year="1997">[1997] IRLR 677</ref>).
+                                </span>
+                            </p>
+                        </content>
+                    </subparagraph>
+                    <subparagraph>
+                        <num style="font-size:12pt">3.</num>
+                        <content>
+                            <p class="ListParagraph" style="text-align:justify;margin-left:1in;margin-right:0.5in;text-indent:-1in">
+                                <span style="font-size:12pt">Any award of compensation made under the <ref href="http://www.legislation.gov.uk/id/ukpga/2010/15" uk:canonical="2010 c. 15" uk:origin="TNA" uk:type="legislation">Equality Act 2010</ref> (“EQA”) is to be assessed under the same principles that apply to torts (sections  124(6) and 119(2) EQA). The aim is to put the claimant in the position, so far as is reasonable, he would have been in had the wrongdoing not occurred (see </span>
+                                <span style="font-style:italic;font-size:12pt">Ministry of Defence v Wheeler</span>
+                                <span style="font-size:12pt">
+                                    <ref href="#" uk:canonical="[1998] IRLR 23" uk:isNeutral="false" uk:origin="TNA" uk:type="case" uk:year="1998">[1998] IRLR 23</ref>; and </span>
+                                <span style="font-style:italic;font-size:12pt">Chagger v Abbey National plc</span>
+                                <span style="font-size:12pt">
+                                    <ref href="#" uk:canonical="[2010] IRLR 47" uk:isNeutral="false" uk:origin="TNA" uk:type="case" uk:year="2010">[2010] IRLR 47</ref>).
+                                </span>
+                            </p>
+                        </content>
+                    </subparagraph>
+                    <subparagraph>
+                        <num style="font-size:12pt">4.</num>
+                        <content>
+                            <p class="ListParagraph" style="text-align:justify;margin-left:1in;margin-right:0.5in;text-indent:-1in">
+                                <span style="font-size:12pt">Causation and remoteness limit the damages available to a claimant: only those losses caused by the unlawful conduct will be recoverable. However, any loss proved to flow directly from the discriminatory act will be recoverable (see </span>
+                                <span style="font-style:italic;font-size:12pt">Essa v Laing Ltd</span>
+                                <span style="font-size:12pt">
+                                    <ref href="#" uk:canonical="[2004] ICR 746" uk:isNeutral="false" uk:origin="TNA" uk:type="case" uk:year="2004">[2004] ICR 746</ref>).
+                                </span>
+                            </p>
+                        </content>
+                    </subparagraph>
+                    <subparagraph>
+                        <num style="font-size:12pt">5.</num>
+                        <content>
+                            <p class="ListParagraph" style="text-align:justify;margin-left:1in;margin-right:0.5in;text-indent:-1in">
+                                <span style="font-size:12pt">A claimant is expected to take reasonable steps to mitigate the losses they suffered as a result of the unlawful conduct. The burden is on the respondent to prove that there had been a failure to mitigate such losses (see </span>
+                                <span style="font-style:italic;font-size:12pt">Fyfe v Scientific Furnishing Ltd</span>
+                                <span style="font-size:12pt">
+                                    <ref href="#" uk:canonical="[1989] IRLR 331" uk:isNeutral="false" uk:origin="TNA" uk:type="case" uk:year="1989">[1989] IRLR 331</ref>). …
+                                </span>
+                            </p>
+                        </content>
+                    </subparagraph>
+                    <subparagraph>
+                        <num style="font-size:12pt">6.</num>
+                        <content>
+                            <p class="ListParagraph" style="text-align:justify;margin-left:1in;margin-right:0.5in;text-indent:-1in">
+                                <span style="font-size:12pt">Although credit must be given for any earnings received, the same does not apply to early receipt of a pension following dismissal …”</span>
+                            </p>
+                        </content>
+                    </subparagraph>
+                </paragraph>
+                <paragraph eId="para_91">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">91.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">The issue raised by the respondents’ appeal on remedy relates to the effect of the </span>
+                            <span style="font-weight:bold;font-size:12pt">1996 Regulations</span>
+                            <span style="font-size:12pt">.  It is common ground between the parties that, as the ET found, although it was open to the first respondent to enter into a lawful contract of employment with the claimant, the proposed agreement to continue to employ the claimant as a Locum Consultant until his 60</span>
+                            <span style="vertical-align:super;font-size:12pt">th</span>
+                            <span style="font-size:12pt"> birthday in May 2019 would have been ultra vires as a result of the </span>
+                            <span style="font-weight:bold;font-size:12pt">1996 Regulations</span>
+                            <span style="font-size:12pt">.</span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_92">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">92.</num>
+                    <intro>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">The effect of the </span>
+                            <span style="font-weight:bold;font-size:12pt">1996 Regulations</span>
+                            <span style="font-size:12pt"> was considered by the EAT in </span>
+                            <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt">Shrewsbury and Telford Hospital NHS Trust v Lairikyengbam</span>
+                            <span style="font-size:12pt"> [2010] ICR 66, where it was similarly held: </span>
+                        </p>
+                    </intro>
+                    <subparagraph>
+                        <num style="font-size:12pt">“35.</num>
+                        <content>
+                            <p class="ListParagraph" style="text-align:justify;margin-left:1in;margin-right:0.5in;text-indent:-1in">
+                                <span style="font-size:12pt">… it cannot be said that the [1996] Regulations are not mandatory but merely procedural and directive.  Whilst the trust has a general power to appoint staff, that power is circumscribed by the [1996] Regulations. …</span>
+                            </p>
+                        </content>
+                    </subparagraph>
+                    <subparagraph>
+                        <content>
+                            <p class="ListParagraph" style="text-align:justify;margin-left:1in;margin-right:0.5in">
+                                <span style="font-size:12pt">…</span>
+                            </p>
+                        </content>
+                    </subparagraph>
+                    <subparagraph>
+                        <num style="font-size:12pt">38.</num>
+                        <content>
+                            <p class="ListParagraph" style="text-align:justify;margin-left:1in;margin-right:0.5in;text-indent:-1in">
+                                <span style="font-size:12pt">The trust had no power to employ a consultant in respect of whose appointment the 1996 Regulations had not been complied with. …” </span>
+                            </p>
+                        </content>
+                    </subparagraph>
+                </paragraph>
+                <paragraph eId="para_93">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">93.</num>
+                    <intro>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">In </span>
+                            <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt">Lairikyengbam</span>
+                            <span style="font-size:12pt">, the EAT observed that this gave rise to a particular difficulty where an employee had in fact continued to be employed contrary to the requirements of the </span>
+                            <span style="font-weight:bold;font-size:12pt">1996 Regulations</span>
+                            <span style="font-size:12pt">:</span>
+                        </p>
+                    </intro>
+                    <subparagraph>
+                        <num style="font-size:12pt">“39.</num>
+                        <content>
+                            <p class="ListParagraph" style="text-align:justify;margin-left:1in;margin-right:0.5in;text-indent:-1in">
+                                <span style="font-size:12pt">Difficulties arise in the employment context where a former employee of a public body continues working under an ultra vires arrangement.  That body may, as here, have the power to employ the individual but not in the circumstances in which he or she was employed.  The courts then have to consider the nature of the arrangement under which they work.  This is a difficult a question. …”</span>
+                            </p>
+                        </content>
+                    </subparagraph>
+                </paragraph>
+                <paragraph eId="para_94">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">94.</num>
+                    <intro>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">In seeking to answer that question, the EAT considered the approach of the Court of Appeal in </span>
+                            <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt">Eastbourne Borough Council v Foster</span>
+                            <span style="font-size:12pt">
+                                <ref href="#" uk:canonical="[2002] ICR 234" uk:isNeutral="false" uk:origin="TNA" uk:type="case" uk:year="2002">[2002] ICR 234</ref> provided a helpful analysis.  In </span>
+                            <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt">Foster</span>
+                            <span style="font-size:12pt">, it had been held at first instance that the ultra vires arrangement under which Mr Foster had been employed pursuant to a compromise agreement meant:</span>
+                        </p>
+                    </intro>
+                    <subparagraph>
+                        <num style="font-size:12pt">“19.</num>
+                        <content>
+                            <p class="ListParagraph" style="text-align:justify;margin-left:1in;margin-right:0.5in;text-indent:-1in">
+                                <span style="font-size:12pt">… he was not under any contract of employment at any time thereafter, nor (probably) was he in any other contractual relationship with the [employer] …”</span>
+                            </p>
+                        </content>
+                    </subparagraph>
+                </paragraph>
+                <paragraph eId="para_95">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">95.</num>
+                    <intro>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">Before the Court of Appeal, Mr Foster argued that the ineffectiveness of the ultra vires compromise agreement meant that his original, lawful, contract had continued or, alternatively, that there was a continued “</span>
+                            <span style="font-style:italic;font-size:12pt">relationship of employment</span>
+                            <span style="font-size:12pt">”.  For the Council, however, it was contended that it would be impermissible to achieve the result of an ultra vires arrangement by other means.  Rix LJ, with whom Aldous and May LJJ agreed, held:</span>
+                        </p>
+                    </intro>
+                    <subparagraph>
+                        <num style="font-size:12pt;color:#000000">“32.</num>
+                        <content>
+                            <p style="text-align:justify;margin-left:1in;margin-right:0.5in;text-indent:0.5in">
+                                <span style="font-size:12pt;color:#000000">In my judgment, the correct analysis lies between these two positions. Although it is impermissible to accord any validity to the compromise agreement and I agree that it therefore follows that no reliance can be placed on any promise or representation that merely reflects an alternative legal foundation for binding the council to an undertaking that it had no power to give, nevertheless the conduct of the parties still exists in the real world and cannot be ignored for all purposes.</span>
+                            </p>
+                        </content>
+                    </subparagraph>
+                    <subparagraph>
+                        <content>
+                            <p style="text-align:justify;margin-left:1in;margin-right:0.5in">
+                                <span style="font-size:12pt;color:#000000">…</span>
+                            </p>
+                        </content>
+                    </subparagraph>
+                    <subparagraph>
+                        <num style="font-size:12pt;color:#000000">35.</num>
+                        <content>
+                            <p style="text-align:justify;margin-left:1in;margin-right:0.5in;text-indent:0.5in">
+                                <span style="font-size:12pt;color:#000000">In my judgment, Mr Foster's employment by the Council continued, but on a new basis. … [I]t seems to me that not to accept that the relationship and status of employment continued is to acknowledge less than the reality of the situation demands, while at the same time to accept the reality of that relationship is to do no more than the invalidity of the compromise agreement allows. In other words, I believe that this solution does justice both to the facts that occurred, and to the doctrine of ultra vires and thus to the need to ignore, and not by other means to give effect to, the false formal basis upon which the parties mistakenly believed themselves to be acting.”</span>
+                            </p>
+                        </content>
+                    </subparagraph>
+                </paragraph>
+                <paragraph eId="para_96">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">96.</num>
+                    <intro>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">Having considered the approach adopted by the court in </span>
+                            <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt">Craven-Ellis v Canons Ltd</span>
+                            <span style="font-size:12pt"> [1936] 2 KB 403 CA (where a director who had carried out services under a void contract was held to be entitled to be paid for his work on a quantum meruit basis), as approved by Lord Templeman in </span>
+                            <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt">Guinness plc v Saunders</span>
+                            <span style="font-size:12pt"> [1990] 2 AC 663, 693, Rix LJ continued:</span>
+                        </p>
+                    </intro>
+                    <subparagraph>
+                        <num style="font-size:12pt;color:#000000">“43.</num>
+                        <content>
+                            <p style="text-align:justify;margin-left:1in;margin-right:0.5in;text-indent:0.5in">
+                                <span style="font-size:12pt;color:#000000">Whether the obligation imposed by law in such a case is normally described as contractual, quasi-contractual or restitutionary, may not matter for the purposes of this case, since in any event I would consider that where, as here, the relationship between the parties is best described as a relationship of employment the law must necessarily impose a contractual solution.  I do not think that is even inconsistent with the parallel existence of restitutionary remedies. Thus, in this case, it is possible to say that in contract Mr Foster was entitled to claim reasonable remuneration for the work that he did, or in other words quantum meruit, whilst in restitution he was both prima facie obliged to return the sums he received under the void compromise agreement and at the same time entitled to a defence of change of position.”</span>
+                            </p>
+                        </content>
+                    </subparagraph>
+                </paragraph>
+                <paragraph eId="para_97">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">97.</num>
+                    <intro>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">The judgment in </span>
+                            <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt">Foster</span>
+                            <span style="font-size:12pt"> is binding upon me, although I note the following commentary in </span>
+                            <span style="font-style:italic;font-size:12pt">Chitty on Contracts</span>
+                            <span style="font-size:12pt"> 34</span>
+                            <span style="vertical-align:super;font-size:12pt">th</span>
+                            <span style="font-size:12pt"> edn, at 13-044, as follows:</span>
+                        </p>
+                    </intro>
+                    <subparagraph>
+                        <content>
+                            <p class="ListParagraph" style="text-align:justify;margin-left:1in;margin-right:0.5in">
+                                <span style="font-size:12pt;color:#3D3D3D">“Where a contract has been found to be ultra vires, it may be possible to infer a different, intra vires contract, from the dealings between the parties. Thus, in </span>
+                                <a href="https://uk.westlaw.com/Link/Document/FullText?findType=Y&amp;serNum=2001569738&amp;pubNum=6448&amp;originatingDoc=IB16FE1306F4711E78AB0DD5C39CC2AEA&amp;refType=UC&amp;originationContext=document&amp;transitionType=CommentaryUKLink&amp;ppcid=0b9dfc26af084d7f8c10dd0ae2fe44a4&amp;contextData=(sc.Search)">
+                                    <span class="Emphasis" style="font-size:12pt">Eastbourne BC v Foster</span>
+                                </a>
+                                <span style="font-size:12pt;color:#3D3D3D"> the … Court of Appeal held that whilst the ultra vires contract must be disregarded, the conduct of the parties showed that a relationship of employment continued to exist between them, and the employee was entitled to claim for work done on a contractual basis. Unfortunately, the reasoning of the Court of Appeal is not free from difficulty. </span>
+                            </p>
+                        </content>
+                    </subparagraph>
+                    <subparagraph>
+                        <content>
+                            <p class="ListParagraph" style="text-align:justify;margin-left:1in;margin-right:0.5in">
+                                <span style="font-size:12pt;color:#3D3D3D">…</span>
+                            </p>
+                        </content>
+                    </subparagraph>
+                    <subparagraph>
+                        <content>
+                            <p class="ListParagraph" style="text-align:justify;margin-left:1in;margin-right:0.5in">
+                                <span style="font-size:12pt;color:#3D3D3D">It is submitted that it was very unfortunate that the Court invoked the idea of a “quasi-contractual” obligation, since it is now widely accepted that “quasi-contract” is a misleading and unhelpful label. It is also regrettable that the Court regarded the quantum meruit remedy as “contractual”, since this blurred the fundamental distinction between claims for breach of contract, and claims in unjust enrichment. Furthermore, it seems to be rather artificial to regard the employee as having implicitly contracted to do work for a “reasonable remuneration” when in fact he had expressly agreed to do it for his full salary. The artificiality of the contractual analysis suggests that greater consideration should have been given to the possibility of analysing the situation purely in terms of unjust enrichment. This could have been done by regarding the services provided by the employee as having been performed on the understanding, subsequently shown to be incorrect, that a valid contractual obligation existed for remuneration. In other words, the situation could have been analysed in terms of failure of basis. This analysis has three advantages over the contractual analysis. First, it avoids the need to construct a parallel, implicit contract on different terms to the agreement actually made between the parties. Second, it is a more accurate reflection of what actually took place. Third, it has the advantage of simplicity, since it eliminates the need to investigate any potential relationship between claims in contract and for unjust enrichment.”</span>
+                            </p>
+                        </content>
+                    </subparagraph>
+                </paragraph>
+                <paragraph eId="para_98">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">98.</num>
+                    <intro>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">In </span>
+                            <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt">Mohamed v Alaga &amp; Co</span>
+                            <span style="font-size:12pt">
+                                <ref href="#" uk:canonical="[2000] 1 WLR 1815" uk:isNeutral="false" uk:origin="TNA" uk:type="case" uk:year="2000">[2000] 1 WLR 1815</ref> CA, it was conceded that a claimant could not avoid the consequences of an illegal contract by relabelling the ground of claim in quasi contract or restitution (see the judgment of Lord Bingham CJ at p 1824G-H).  As was recognised in that case, however, it would still be open for such a claimant to pursue a quantum meruit claim for reasonable remuneration for services rendered; as Lord Bingham observed (see p 1825D):</span>
+                        </p>
+                    </intro>
+                    <subparagraph>
+                        <content>
+                            <p class="ListParagraph" style="text-align:justify;margin-left:1in;margin-right:0.5in">
+                                <span style="font-size:12pt">“… the preferable view … is that the [claimant] is not seeking to recover any part of the consideration payable under the unlawful contract, but simply a reasonable reward for professional services rendered. …”</span>
+                            </p>
+                        </content>
+                    </subparagraph>
+                </paragraph>
+                <paragraph eId="para_99">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">99.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">Lord Bingham further recorded that the situation in that case was not one in which the parties’ “</span>
+                            <span style="font-style:italic;font-size:12pt">blameworthiness is equal</span>
+                            <span style="font-size:12pt">”, the position of the claimant being somewhat less reprehensible than that of the defendants (see p 1825E-F).</span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_100">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">100.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">Returning to the employment context, in </span>
+                            <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt">Foster</span>
+                            <span style="font-size:12pt">, it was held to be material that, notwithstanding the ultra vires nature of the compromise agreement, there had been no general prohibition which prevented the Council from employing Mr Foster.  So too, in </span>
+                            <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt">Lairikyengbam</span>
+                            <span style="font-size:12pt">, the EAT noted that, although Mr Lairikyengbam could not continue to be employed as a Consultant, there was no general prohibition on his employment by the NHS Trust; at the relevant time, therefore, Mr Lairikyengbam was to be treated as performing his duties under a contract of employment. </span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_101">
+                    <num style="font-family:'Times New Roman';font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">101.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">Where a claim of unlawful discrimination arises from an employment relationship where the contract of employment is tainted by illegality, it has been held that this should not amount to a bar to the employee’s remedy before the ET unless they were a knowing participant in that illegality; </span>
+                            <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt">Hall v Woolston Hall Leisure Ltd</span>
+                            <span style="font-size:12pt">
+                                <ref href="#" uk:canonical="[2001] ICR 99" uk:isNeutral="false" uk:origin="TNA" uk:type="case" uk:year="2001">[2001] ICR 99</ref> CA.  That guidance now needs to be read subject to the Supreme Court decisions in </span>
+                            <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt">Hounga v Allen</span>
+                            <span style="font-size:12pt">
+                                <ref href="https://caselaw.nationalarchives.gov.uk/uksc/2014/47" uk:canonical="[2014] UKSC 47" uk:isNeutral="true" uk:origin="TNA" uk:type="case" uk:year="2014">[2014] UKSC 47</ref> and </span>
+                            <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt">Patel v Mirza</span>
+                            <span style="font-size:12pt">
+                                <ref href="https://caselaw.nationalarchives.gov.uk/uksc/2016/42" uk:canonical="[2016] UKSC 42" uk:isNeutral="true" uk:origin="TNA" uk:type="case" uk:year="2016">[2016] UKSC 42</ref>.  In </span>
+                            <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt">Patel v Mirza</span>
+                            <span style="font-size:12pt">, the majority of the Supreme Court held that the real question was whether the public interest would be harmed by enforcement of the illegal agreement, considering (a) the underlying purpose of the prohibition transgressed and whether that purpose would be enhanced by a denial of the claim; (b) any other relevant public policy on which a denial of the claim might impact; (c) whether denial of the claim would be a proportionate response to the illegality.</span>
+                        </p>
+                    </content>
+                </paragraph>
+                <level>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify">
+                            <span style="font-weight:bold;font-size:12pt">The Remedy Appeal: Discussion and Conclusions</span>
+                        </p>
+                    </content>
+                </level>
+                <paragraph eId="para_102">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">102.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">The issue raised by this appeal relates to the ET’s assessment of the claimant’s losses from the date of the termination of his employment (the relevant discriminatory act) to the ET remedy hearing (the relevant date of assessment).  An award of damages in this context should seek to place a claimant into the position they would have been in if the wrong had not been sustained (</span>
+                            <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt">Chagger</span>
+                            <span style="font-size:12pt">).  In the present case, the ET thus had to assess, on a hypothetical basis, what would have happened had the claimant’s employment not been brought to an end by reason of the respondents’ discrimination.  </span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_103">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">103.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">Carrying out this task, the ET concluded that the parties would have entered into an agreement by which, as a matter of fact, the claimant’s existing contract as a Locum Consultant would have been continued but under an extended notice period of nine months, leading to the termination of his contract at the end of February 2019 (although the ET found that period would then have been further extended by three months until the claimant’s retirement, age 60, in May 2019).  As the ET further concluded, and as the parties agree, the effect of the </span>
+                            <span style="font-weight:bold;font-size:12pt">1996 Regulations</span>
+                            <span style="font-size:12pt"> meant that agreement would have been unlawful.  On the ET’s findings, however, that would not have meant that the claimant would not in fact have worked for the first respondent, carrying out the duties of a Locum Consultant, for that period.  On the contrary, his employment relationship with the first respondent would have continued and he would have carried out services “</span>
+                            <span style="font-style:italic;font-size:12pt">on locum consultant duties as before</span>
+                            <span style="font-size:12pt">” (see the citation at paragraph 41, remedy judgment).  That, after all, had been the position of the claimant and a number of other Locum Consultants prior to the respondents’ appreciation of the regulatory issue in 2017, and that, as the ET found, continued to be the position in relation to Mr Hakky throughout the period in question (May 2018-May 2019) (paragraph 49, remedy judgment).  Indeed, the ET concluded, given that the arrangement had been sanctioned by the Medical Director’s Office, the view within the first respondent at the time was that this would have been lawful (again, see the citations at paragraph 41, remedy judgment). </span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_104">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">104.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">Moreover, although the agreement between the parties would itself have been unlawful, it is not suggested that this is a case where the first respondent would otherwise have been unable to enter into a lawful contract of employment with the claimant; as in </span>
+                            <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt">Lairikyengbam</span>
+                            <span style="font-size:12pt">, the </span>
+                            <span style="font-weight:bold;font-size:12pt">1996 Regulations</span>
+                            <span style="font-size:12pt"> meant that the first respondent could not continue to employ the claimant in a Consultant capacity, not that it was prohibited from employing him at all (in contrast, for example, to the position in </span>
+                            <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt">Secretary of State for Justice v Betts and ors</span>
+                            <span style="font-size:12pt"> UKEAT/0284/16).  At the remedy hearing in October 2021, therefore, when the ET came to assess damages for past loss of earnings, it did so on the basis of a hypothetical scenario in which the claimant would have continued to be in a lawful employment relationship with the first respondent but would have provided Locum Consultant services pursuant to an unlawful agreement with his employer.  </span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_105">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">105.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">The respondents contend that the unlawful nature of the agreement between the claimant and the first respondent ought to have been fatal to any claim for past loss of earnings for the relevant period (May 2018-May 2019).  It is said that the ET ought not to have awarded compensation for a period during which the claimant could not lawfully have carried out his work (per </span>
+                            <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt">Okukusie</span>
+                            <span style="font-size:12pt">), and, although a claim might be brought on quantum meruit principles, that would depend upon the claimant having actually performed the work in question and would still be subject to the public policy concern that a court ought not “</span>
+                            <span style="font-style:italic;font-size:12pt;color:#000000">give effect to a false formal basis upon which the parties mistakenly believed themselves to be acting</span>
+                            <span style="font-size:12pt;color:#000000">” (per Rix LJ in </span>
+                            <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt;color:#000000">Foster</span>
+                            <span style="font-size:12pt;color:#000000">).</span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_106">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">106.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">I do not consider that the circumstances of the present case fall to be analysed in the same way as those in </span>
+                            <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt">Okukusie</span>
+                            <span style="font-size:12pt">.  In </span>
+                            <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt">Okukusie</span>
+                            <span style="font-size:12pt">, the claimant’s immigration status meant that he could not lawfully work in this country at the relevant time; the ET had erred in making an award of compensation for unfair dismissal in that case on the (erroneous) assumption that the claimant could have continued in his employment.  In the present case, the first respondent could lawfully have continued to employ the claimant; the unlawful nature of the arrangement it was offering arose from the fact that this employment was to be in a Consultant capacity, not from the fact of the continued employment </span>
+                            <span style="font-style:italic;font-size:12pt">per se</span>
+                            <span style="font-size:12pt">.  </span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_107">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">107.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">Furthermore, although the </span>
+                            <span style="font-weight:bold;font-size:12pt">1996 Regulations</span>
+                            <span style="font-size:12pt"> meant that the claimant could not lawfully have been employed by the first respondent in a Consultant capacity, the ET found that  he would in fact have continued to carry out such duties for around a year, up to 18 May 2019.  An award of damages that placed the claimant into the position he would have been in if he had not suffered unlawful discrimination would therefore need to recognise that fact.  Following the approach in </span>
+                            <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt">Foster</span>
+                            <span style="font-size:12pt">, the ET could do so by awarding the claimant compensation for the services it considered he would have performed over the period in question.  That, it seems to me must be the correct approach to the award of tortious damages in this context, whether it is analysed (</span>
+                            <span style="font-style:italic;font-size:12pt">per</span>
+                            <span style="font-size:12pt"> the Court of Appeal in </span>
+                            <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt">Foster</span>
+                            <span style="font-size:12pt">) on the basis of an alternative contractual arrangement subsisting between the parties or whether it is seen (</span>
+                            <span style="font-style:italic;font-size:12pt">per </span>
+                            <span style="font-size:12pt">the commentary in </span>
+                            <span style="font-weight:bold;text-decoration-line:underline;text-decoration-style:solid;font-size:12pt">Chitty</span>
+                            <span style="font-size:12pt">) as a restitutionary remedy, the claimant having (on the ET’s finding) provided services on the understanding (subsequently shown to be incorrect) that a valid contractual obligation existed for remuneration.  </span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_108">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">108.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">Moreover, I do not consider that this result is precluded by the fact that the ET was making an award in respect of what it found would have happened on a hypothetical basis; that, after all, was the nature of the exercise it was required to undertake.  This was not a case where the ET was looking ahead and awarding compensation for future losses founded upon an unlawful contract.  Rather, it was looking back to compensate the claimant for the loss it found he had already suffered as a result of the respondents’ discriminatory conduct.  </span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_109">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">109.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">This result does not, in my judgement, offend public policy.  By compensating the claimant for what it had held would have occurred had he not suffered unlawful discrimination, the ET was recognising the reality of the claimant’s loss on the counterfactual basis it had found.  Its award of damages for past pecuniary losses neither condoned an unlawful contract nor offended public policy more generally.  On the contrary, had the ET declined to make an award of compensation for past pecuniary loss in these circumstances, it would have failed to put the claimant in the position that it had found he would have been in had the wrongdoing not occurred.   The respondents would thus avoid the consequences of their unlawful discrimination and the claimant would be deprived of the compensation otherwise due to him for his loss.  I cannot see that any relevant public policy consideration would thereby be enhanced.  </span>
+                        </p>
+                    </content>
+                </paragraph>
+                <paragraph eId="para_110">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">110.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">Moreover, there is no suggestion that either party would have entered into the agreement in question knowing it to be unlawful.  As the ET found, the offer of an extended notice period on this basis was viewed as lawful within the first respondent and there is nothing that would suggest that the claimant would have seen the matter any differently (or that he would have had any reason for doing so).  In the circumstances of this case, I cannot see that the denial of the award of damages for past pecuniary losses would be a proportionate response to the subsequent identification of the unlawful nature of the arrangement the ET found the parties would have entered into. </span>
+                        </p>
+                    </content>
+                </paragraph>
+                <level>
+                    <content>
+                        <p style="text-align:justify;margin-right:0.24in">
+                            <span style="font-weight:bold;font-size:12pt">Disposal</span>
+                        </p>
+                    </content>
+                </level>
+                <paragraph eId="para_111">
+                    <num style="font-size:12pt;color:#000000;margin-left:0.5in;text-indent:-0.5in">111.</num>
+                    <content>
+                        <p class="ListParagraph" style="text-align:justify;margin-left:0.5in;margin-right:0.24in">
+                            <span style="font-size:12pt">For all the reasons provided, I therefore dismiss the respondents’ appeals.  </span>
+                        </p>
+                    </content>
+                </paragraph>
+            </decision>
+        </judgmentBody>
+    </judgment>
+</akomaNtoso>

--- a/development_scripts/fixtures/eat-2023-1-properties.xml
+++ b/development_scripts/fixtures/eat-2023-1-properties.xml
@@ -1,0 +1,22 @@
+<rapi:metadata xmlns:rapi="http://marklogic.com/rest-api"
+               xmlns:prop="http://marklogic.com/xdmp/property">
+<prop:properties>
+    <source-organisation>HM Courts and Tribunals Service</source-organisation>
+    <source-name>Tess Testerton</source-name>
+    <source-email>tess.testerton@justice.gov.uk</source-email>
+    <transfer-consignment-reference>TDR-1999-ABC</transfer-consignment-reference>
+    <transfer-received-at>2023-03-16T16:09:31Z</transfer-received-at>
+    <published>true</published>
+    <last_sent_to_enrichment>2024-11-20T15:27:31.295578+00:00</last_sent_to_enrichment>
+    <last_sent_to_parser>2024-07-10T16:46:41.191852+00:00</last_sent_to_parser>
+    <identifiers>
+        <identifier>
+            <namespace>ukncn</namespace>
+            <uuid>id-3bd89bc3-6341-46e2-b130-d7ffe8098319</uuid>
+            <value>[2023] EAT 1</value>
+            <url_slug>eat/2023/1</url_slug>
+        </identifier>
+    </identifiers>
+    <prop:last-modified>2025-01-14T11:59:04Z</prop:last-modified>
+</prop:properties>
+</rapi:metadata>

--- a/development_scripts/populate_from_caselaw.py
+++ b/development_scripts/populate_from_caselaw.py
@@ -12,6 +12,8 @@ Usage:
 - Run the script.
 """
 
+from pathlib import Path
+
 import requests
 
 urls = [
@@ -19,7 +21,6 @@ urls = [
     "ewca/civ/2003/1048",
     "ewca/civ/2003/1489",
     "ewca/civ/2003/48",
-    "eat/2023/1",
     "eat/2023/2",
 ]
 
@@ -37,3 +38,22 @@ for url in urls:
     )
     response.raise_for_status()
     print("added to local Marklogic db")
+
+for filename in ["eat-2023-1"]:
+    ml_url = "/" + filename.replace("-", "/") + ".xml"
+    with Path(f"development_scripts/fixtures/{filename}-content.xml").open() as f:
+        content = f.read()
+    with Path(f"development_scripts/fixtures/{filename}-properties.xml").open() as f:
+        properties = f.read()
+    response = requests.put(
+        f"http://admin:admin@localhost:8011/LATEST/documents?uri={ml_url}&collection=judgment",
+        data=content,
+    )
+    response.raise_for_status()
+    response = requests.put(
+        f"http://admin:admin@localhost:8011/LATEST/documents?uri={ml_url}&category=properties",
+        data=properties,
+    )
+    print(response.content)
+    response.raise_for_status()
+    print(f"added {filename} to local Marklogic db")


### PR DESCRIPTION
PUI end to end tests were failing because they relied on real document properties existing -- now we load a real fixture with properties.

This might be a model for future more reproducible tests that don't just copy off prod.

In future we might want to remove the CI task that publishes all the things.