### PR TITLE
Merge identifiers into search response reattempt

### DIFF
--- a/development_scripts/fixtures/eat-2023-1-properties.xml
+++ b/development_scripts/fixtures/eat-2023-1-properties.xml
@@ -1,24 +1,6 @@
 <rapi:metadata xmlns:rapi="http://marklogic.com/rest-api"
                xmlns:prop="http://marklogic.com/xdmp/property">
 <prop:properties>
-<dls:version xmlns:dls="http://marklogic.com/xdmp/dls">
-<dls:latest>true
-</dls:latest>
-<dls:created>2025-02-26T17:54:17.834153Z
-</dls:created>
-<dls:author>7071164303237443533
-</dls:author>
-<dls:external-security-id>0
-</dls:external-security-id>
-<dls:external-user-name>
-</dls:external-user-name>
-<dls:annotation>
-</dls:annotation>
-<dls:deleted>false
-</dls:deleted>
-</dls:version>
-<dls:update-permissions xmlns:dls="http://marklogic.com/xdmp/dls">
-</dls:update-permissions>
     <source-organisation>HM Courts and Tribunals Service</source-organisation>
     <source-name>Tess Testerton</source-name>
     <source-email>tess.testerton@justice.gov.uk</source-email>

--- a/development_scripts/populate_from_caselaw.py
+++ b/development_scripts/populate_from_caselaw.py
@@ -65,4 +65,14 @@ for filename in ["eat-2023-1"]:
         data=properties,
     )
     test_response(response)
+
+    xquery = f"""
+    xquery version "1.0-ml";
+    import module namespace dls = "http://marklogic.com/xdmp/dls" at "/MarkLogic/dls.xqy";
+    dls:document-manage("{ml_url}", fn:false())
+    """
+
+    response = requests.post("http://admin:admin@localhost:8011/LATEST/eval", data={"xquery": xquery})
+
+    print(response.content)
     print(f"added {filename} to local Marklogic db")

--- a/development_scripts/populate_top_judgments_and_neighbours.py
+++ b/development_scripts/populate_top_judgments_and_neighbours.py
@@ -1,3 +1,4 @@
+#!python3
 """
 This script retrieves XML data from the live TNA caselaw website and updates a local MarkLogic database.
 

--- a/src/main/ml-modules/root/judgments/search/helper.xqy
+++ b/src/main/ml-modules/root/judgments/search/helper.xqy
@@ -308,11 +308,14 @@ declare private variable $snippet-filter := <xsl:stylesheet xmlns:xsl="http://ww
     </xsl:template>
 </xsl:stylesheet>;
 
-declare function add-property-to-search($search-results, $property-name) {
-    let $result-uri := $search-results//search:result/@uri
-    let $identifiers := xdmp:document-get-properties($result-uri, xs:QName($property-name))
+declare function add-properties-to-search($search-results) {
+    let $result-uris := $search-results//search:result/@uri
+
+    (: get a map of uri: identifiers for insertion later :)
+    let $identifiers := xdmp:document-get-properties($result-uris, xs:QName("identifiers"))
     let $identifier-map := map:map()
-    let $_ := for $uri in $result-uri return map:put($identifier-map, $uri, xdmp:document-get-properties($uri, xs:QName("identifiers")))
+    let $_ := for $uri in $result-uris return map:put($identifier-map, $uri, xdmp:document-get-properties($uri, xs:QName("identifiers")))
+
     let $params := map:new(
         map:entry(xdmp:key-from-QName(fn:QName("", "identifier-map")), $identifier-map)
     )
@@ -334,7 +337,7 @@ declare function add-property-to-search($search-results, $property-name) {
                 </xsl:copy>
                 <!-- Add new node -->
                 <xsl:variable name="uri" select="ancestor::search:result/@uri"/>
-                <search:extracted kind="{{$property-name}}"><xsl:copy-of select="map:get($identifier-map, $uri)"/></search:extracted>
+                <search:extracted kind="identifiers"><xsl:copy-of select="map:get($identifier-map, $uri)"/></search:extracted>
             </xsl:template>
         </xsl:stylesheet>
 

--- a/src/main/ml-modules/root/judgments/search/helper.xqy
+++ b/src/main/ml-modules/root/judgments/search/helper.xqy
@@ -9,6 +9,7 @@ import module namespace json = "http://marklogic.com/xdmp/json"
 
 declare namespace akn = "http://docs.oasis-open.org/legaldocml/ns/akn/3.0";
 declare namespace uk = "https://caselaw.nationalarchives.gov.uk";
+declare namespace search = "http://marklogic.com/appservices/search";
 
 declare variable $default-options as xs:string* := ( 'case-insensitive' );
 
@@ -306,3 +307,37 @@ declare private variable $snippet-filter := <xsl:stylesheet xmlns:xsl="http://ww
         </xsl:copy>
     </xsl:template>
 </xsl:stylesheet>;
+
+declare function add-property-to-search($search-results, $property-name) {
+    let $result-uri := $search-results//search:result/@uri
+    let $identifiers := xdmp:document-get-properties($result-uri, xs:QName($property-name))
+    let $identifier-map := map:map()
+    let $_ := for $uri in $result-uri return map:put($identifier-map, $uri, xdmp:document-get-properties($uri, xs:QName("identifiers")))
+    let $params := map:new(
+        map:entry(xdmp:key-from-QName(fn:QName("", "identifier-map")), $identifier-map)
+    )
+    let $merge-properties :=
+        <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+            xmlns:search="http://marklogic.com/appservices/search"
+            xmlns:map="http://marklogic.com/xdmp/map">
+            <xsl:param name="identifier-map"/>
+            <xsl:template match="/ | @* | node()">
+                <xsl:copy>
+                    <xsl:apply-templates select="@* | node()" />
+                </xsl:copy>
+            </xsl:template>
+            <xsl:template match="search:extracted">
+                <!-- Copy the element -->
+                <xsl:copy>
+                    <!-- And everything inside it -->
+                    <xsl:apply-templates select="@* | node()"/>
+                </xsl:copy>
+                <!-- Add new node -->
+                <xsl:variable name="uri" select="ancestor::search:result/@uri"/>
+                <search:extracted kind="{{$property-name}}"><xsl:copy-of select="map:get($identifier-map, $uri)"/></search:extracted>
+            </xsl:template>
+        </xsl:stylesheet>
+
+
+    return xdmp:xslt-eval($merge-properties, $search-results, $params)
+    };

--- a/src/main/ml-modules/root/judgments/search/search-v2.xqy
+++ b/src/main/ml-modules/root/judgments/search/search-v2.xqy
@@ -198,8 +198,5 @@ let $search-options := <options xmlns="http://marklogic.com/appservices/search">
 let $boosted-query := helper:boost-title-and-ncn($q, $query)
 
 let $results := search:resolve(element x { $boosted-query }/*, $search-options, $start, $page-size)
-let $total as xs:integer := xs:integer($results/@total)
-let $pages as xs:integer := if ($total mod $page-size eq 0) then $total idiv $page-size else $total idiv $page-size + 1
-let $params := $params => map:with('pages', $pages)
 
-return $results
+return helper:add-property-to-search($results, "identifiers")

--- a/src/main/ml-modules/root/judgments/search/search-v2.xqy
+++ b/src/main/ml-modules/root/judgments/search/search-v2.xqy
@@ -199,4 +199,4 @@ let $boosted-query := helper:boost-title-and-ncn($q, $query)
 
 let $results := search:resolve(element x { $boosted-query }/*, $search-options, $start, $page-size)
 
-return helper:add-property-to-search($results, "identifiers")
+return helper:add-properties-to-search($results)


### PR DESCRIPTION
* Fix the error which was causing the XQuery to fail.
* Still has an issue with the API client caused by there being a new encoding declaration and the API client mistakenly trying to manually decode it, but that's probably best fixed in the API client.

Blocked on https://github.com/nationalarchives/ds-caselaw-custom-api-client/pull/913 being deployed.