### PR TITLE
Add caselaw-execute-sql privilege to PUI user

### DIFF
--- a/src/main/ml-config/security/users/caselaw-public-ui.json
+++ b/src/main/ml-config/security/users/caselaw-public-ui.json
@@ -1,5 +1,5 @@
 {
   "user-name" : "caselaw-public-ui",
   "description" : "The Public UI reader",
-  "role" : [ "rest-reader", "rest-extension-user", "caselaw-reader" ]
+  "role" : [ "rest-reader", "rest-extension-user", "caselaw-reader", "caselaw-execute-sql" ]
 }


### PR DESCRIPTION
The PUI now executes SQL to perform fast lookups against compiled identifier slugs. Add the permission to the PUI user.

This does _not_ enable writing via SQL, as the user still doesn't have any writer roles.