### PR TITLE
Fix PDF only search

### DIFF
--- a/src/main/ml-modules/root/judgments/search/search-v2.xqy
+++ b/src/main/ml-modules/root/judgments/search/search-v2.xqy
@@ -27,7 +27,7 @@ declare variable $from_date as xs:date? := uk:get-request-date($from);
 declare variable $to_date as xs:date? := uk:get-request-date($to);
 declare variable $show_unpublished as xs:boolean? external;
 declare variable $only_unpublished as xs:boolean? external;
-declare variable $only_with_html_representation as xs:boolean? external:= false();
+declare variable $only_with_html_representation as xs:boolean? external;
 declare variable $editor_status as xs:string? external := "";
 declare variable $editor_assigned as xs:string? external := "";
 declare variable $editor_priority as xs:string? external := "";


### PR DESCRIPTION
It turns out that the type of

`declare variable $only_unpublished as xs:boolean? external;` is `boolean`
but the type of 
`declare variable $only_with_html_representation as xs:boolean? external := fn:false();` is `untypedAtomic`

and there are different handling issues...
```
let $bare_if_html := if ($only_with_html_representation) then ("true") else ("false")
let $bare_if_unpublished := if ($only_unpublished) then ("true") else ("false")

return fn:error(xs:QName("x"), 
"OnlyHTML: " || $only_with_html_representation ||
"...only-unpub:" || $only_unpublished ||
"...onlyhtml str: " || xs:string($only_with_html_representation = "false") ||
(: "onlyunpub str: " || xs:string($only_unpublished = "false") || :)
"...onlyhtml fneq: " || xs:string($only_with_html_representation = fn:false()) ||
"...onlyunpub fneq: " || xs:string($only_unpublished = fn:false()) ||
"...onlyhtml type:" || xdmp:type($only_with_html_representation) ||
"...onlyunpub type:" || xdmp:type($only_unpublished) ||
"...onlyhtml bareif:" || $bare_if_html ||
"...onlyunpub bareif:" || $bare_if_unpublished ||
"z")
```

yields


```OnlyHTML: false...only-unpub:false...onlyhtml str: true...onlyhtml fneq: true...onlyunpub fneq: true...onlyhtml type:untypedAtomic...onlyunpub type:boolean...onlyhtml bareif:true...onlyunpub bareif:falsez```

Critically, whilst defaulting to a value of fn:false() works, `if($var)` is true if the variable has defaulted.