### PR TITLE
Ensure that test fixture identifier uuids do not collide

### DIFF
--- a/development_scripts/fixture_data/pdf-test-properties.xml
+++ b/development_scripts/fixture_data/pdf-test-properties.xml
@@ -15,7 +15,7 @@
         <identifiers>
             <identifier>
                 <namespace>ukncn</namespace>
-                <uuid>id-2ff917cf-e54b-4355-92d8-2bee5741f88b</uuid>
+                <uuid>id-cccccccc-e54b-4355-92d8-2bee5741f88c</uuid>
                 <value>[2023] EAT 2</value>
                 <url_slug>eat/2023/2</url_slug>
             </identifier>


### PR DESCRIPTION
We noted that e2etests were failing in CI, but not locally. The [trace viewer](https://trace.playwright.dev/) ([trace](https://github.com/nationalarchives/ds-caselaw-public-ui/actions/runs/15495142145/artifacts/3288686075)) revealed that the recent judgements contained a no-slug, no-name search result.

```context['recent_judgments'] = [<SearchResult eat/2023/1 eat/2023/1 Imperial College Healthcare NHS Trust & Anor v N Matar 2023-01-24 00:00:00>, <SearchResult eat/2023/2 eat/2023/2 Dr Mark Ter-Berg v Simply Smile Manor House Ltd & Ors 2022-10-04 00:00:00>, <SearchResult pdf/test **NO SLUG** **NO NAME** None>]```

Investigating I discovered that the pdf and eat/2023/2 shared a uuid, which is (I think) a unique key in the SQL table, meaning that the database has forgotten one of the values due to this collision.

Make them not collide.