### PR TITLE
Remove reference to pdf fixture

### DIFF
--- a/development_scripts/populate_from_caselaw.py
+++ b/development_scripts/populate_from_caselaw.py
@@ -20,7 +20,6 @@ import requests
 FIXTURE_FILES_TO_IMPORT = [
     "eat-2023-1",
     "eat-2023-2",
-    "pdf-test",
 ]
 
 


### PR DESCRIPTION
Having [deleted the pdf fixture](https://github.com/nationalarchives/ds-caselaw-marklogic/pull/217), there was a stray reference to it by name in the populate_from_caselaw script


```
> Loading pdf-test from filesystem…
Traceback (most recent call last):
  File "/home/runner/work/ds-caselaw-public-ui/ds-caselaw-public-ui/marklogic/./development_scripts/populate_from_caselaw.py", line 79, in <module>
    load_fixture_from_files(file_prefix=filename)
  File "/home/runner/work/ds-caselaw-public-ui/ds-caselaw-public-ui/marklogic/./development_scripts/populate_from_caselaw.py", line 42, in load_fixture_from_files
    with Path("development_scripts", "fixture_data", f"{filename}-content.xml").open("rb") as f:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/pathlib.py", line 1015, in open
    return io.open(self, mode, buffering, encoding, errors, newline)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: 'development_scripts/fixture_data/pdf-test-content.xml'
```