### PR TITLE
Remove importDocuments which fails on Gradle 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,17 +84,6 @@ switch back to the main branch (or any branch) by using `git checkout branchname
 
 TODO: Automatically deploy main to staging, and tags to production using CodeBuild.
 
-## Bulk import
-
-(This hasn't been used in a long time)
-
-Place the XML files you want to import in the `import` folder of this repo, then run
-`gradle importDocuments`. The documents will be imported, and the URI will be set as the
-full file path and name within `import`.
-
-You may want to run `gradle publishAllDocuments` (see below) afterwards. All files
-are automatically put under management on import, so there is no need to run the manage task.
-
 ## Bulk export
 
 To export the latest versions of all documents, for instance for bulk processing, you can use:

--- a/build.gradle
+++ b/build.gradle
@@ -60,15 +60,3 @@ task addAllDocumentsToJudgmentsCollection(type: com.marklogic.gradle.task.CorbTa
   modulePrefix = "add-all-documents-to-judgments-collection"
   threadCount = 16
 }
-
-
-task importDocuments(type: com.marklogic.gradle.task.MlcpTask, dependsOn: ['mlLoadModules']) {
-  classpath = configurations.mlcp
-  command = "IMPORT"
-  database = mlAppName + "-content"
-  fastload = true
-  input_file_path = "import"
-  output_uri_replace = buildscript.sourceFile.getParent() + "/import/" + ",\'/\'"
-  batch_size = 1
-  transaction_size = 1
-}


### PR DESCRIPTION
The importDocuments command which was used to load in the original tranche of judgments has been deprecated for a while and was causing problems with Gradle 9.0 which we appear to have inadvertently upgraded to. Delete it, we'll never use it again.

`No signature of method com.marklogic.gradle.task.MlcpTask.getMainClass() is applicable for argument types: () values []`