### PR TITLE
Ensure docker doesn't expose ports externally

### DIFF
--- a/development_scripts/run_local_docker
+++ b/development_scripts/run_local_docker
@@ -1,11 +1,10 @@
 # There is a bug meaning docker-compose may fail: here is an alternative
 docker run -d \
    --name marklogic \
-   -p 8000:8000 \
-   -p 8001:8001 \
-   -p 8002:8002 \
-   -p 8011:8011 \
-   -p 8012:8012 \
+   -p 127.0.0.1:8000-8002:8000-8002 \
+   -p [::1]:8000-8002:8000-8002 \
+   -p 127.0.0.1:8011-8012:8011-8012 \
+   -p [::1]:8011-8012:8011-8012 \
    -e MARKLOGIC_ADMIN_USERNAME=admin \
    -e MARKLOGIC_ADMIN_PASSWORD=admin \
    -e MARKLOGIC_INIT=true \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,11 +3,10 @@ services:
     container_name: marklogic
     image: marklogicdb/marklogic-db:11.0.3-centos-1.0.2@sha256:446394499c88d191666f5dbf2171c2cfead142c79b20e4b4528db624a87a8653
     ports:
-      - "8000:8000"
-      - "8001:8001"
-      - "8002:8002"
-      - "8011:8011"
-      - "8012:8012"
+      - "127.0.0.1:8000-8002:8000-8002"
+      - "[::1]:8000-8002:8000-8002"
+      - "127.0.0.1:8011-8012:8011-8012"
+      - "[::1]:8011-8012:8011-8012"
     environment:
       MARKLOGIC_ADMIN_USERNAME: admin
       MARKLOGIC_ADMIN_PASSWORD: admin


### PR DESCRIPTION
https://docs.docker.com/engine/network/port-publishing/

> Publishing container ports is insecure by default. Meaning, when you publish a container's ports it becomes available not only to the Docker host, but to the outside world as well.
> If you include the localhost IP address (127.0.0.1, or ::1) with the publish flag, only the Docker host can access the published container port.
> `docker run -p 127.0.0.1:8080:80 -p '[::1]:8080:80' nginx`

A similar warning exists for [ports](https://docs.docker.com/reference/compose-file/services/#ports)
