### PR TITLE
Remove redundant nobody security role

### DIFF
--- a/src/main/ml-config/security/roles/caselaw-nobody-role.json
+++ b/src/main/ml-config/security/roles/caselaw-nobody-role.json
@@ -1,5 +1,0 @@
-{
-  "role-name": "caselaw-nobody",
-  "description": "Unauthenticated user",
-  "role": []
-}

--- a/src/main/ml-config/security/roles/caselaw-reader-role.json
+++ b/src/main/ml-config/security/roles/caselaw-reader-role.json
@@ -1,7 +1,7 @@
 {
   "role-name": "caselaw-reader",
   "description": "Can view documents, not including unpublished documents, but not edit",
-  "role": ["rest-reader", "caselaw-nobody", "dls-user", "caselaw-execute-sql"],
+  "role": ["rest-reader", "dls-user", "caselaw-execute-sql"],
   "privilege": [
     {
       "privilege-name": "xdbc:eval",


### PR DESCRIPTION
This is no longer used as any part of our security model, and can be safely removed.