### PR TITLE
[FCLC-2233] Fix order=updated search extracts and identifiers

### DIFF
--- a/src/main/ml-modules/root/judgments/search/helper.xqy
+++ b/src/main/ml-modules/root/judgments/search/helper.xqy
@@ -312,42 +312,158 @@ declare private variable $snippet-filter := <xsl:stylesheet xmlns:xsl="http://ww
     </xsl:template>
 </xsl:stylesheet>;
 
-declare function add-properties-to-search($search-results) {
+(: ---------------------------------------------------------------------------
+   Paged search: build query/options once in search-v2, then:
+     1. Branch only on how the page is ordered
+     2. Body extracts come from documents-scoped resolve (native or URI hydrate)
+     3. Identifiers: one batched property read for the page, then amalgamate
+   --------------------------------------------------------------------------- :)
+
+(: Public entry: order branch, then shared identifier hydrate + amalgamate. :)
+declare function resolve-paged-search(
+    $query as cts:query,
+    $sort-word as xs:string,
+    $direction as xs:string,
+    $start as xs:integer,
+    $page-size as xs:integer,
+    $document-options as element()
+) {
+    let $body-response :=
+        if ($sort-word = "updated") then
+            resolve-body-by-last-modified($query, $document-options, $start, $page-size, $direction)
+        else
+            ml:resolve(element x { $query }/*, $document-options, $start, $page-size)
+    let $uris as xs:string* :=
+        for $uri in $body-response//search:result/@uri
+        return xs:string($uri)
+    return amalgamate-identifiers($body-response, hydrate-identifiers($uris))
+};
+
+(: order=updated cannot use documents-scoped sort-order: cts:index-order on
+   prop:last-modified is ignored for document searches. Order the page from
+   properties fragments, then hydrate body extracts with one documents resolve. :)
+declare private function resolve-body-by-last-modified(
+    $query as cts:query,
+    $document-options as element(),
+    $start as xs:integer,
+    $page-size as xs:integer,
+    $direction as xs:string
+) {
+    let $index-order := cts:index-order(
+        cts:element-reference(
+            fn:QName("http://marklogic.com/xdmp/property", "last-modified"),
+            ("type=dateTime")
+        ),
+        $direction
+    )
+    let $page-props := fn:subsequence(
+        cts:search(
+            xdmp:document-properties(),
+            cts:document-fragment-query($query),
+            ("unfiltered", $index-order)
+        ),
+        $start,
+        $page-size
+    )
+    let $uris as xs:string* :=
+        for $props in $page-props
+        return xdmp:node-uri($props)
+    let $total := xdmp:estimate(
+        cts:search(
+            xdmp:document-properties(),
+            cts:document-fragment-query($query),
+            "unfiltered"
+        )
+    )
+    (: Facets need the full query on documents; page-length 0 skips result rows. :)
+    let $facets-response := ml:resolve(element x { $query }/*, $document-options, 1, 0)
+
+    let $page-response :=
+        if (fn:empty($uris)) then
+            <search:response total="{$total}" start="{$start}" page-length="0"/>
+        else
+            ml:resolve(
+                element x { cts:document-query($uris) }/*,
+                $document-options,
+                1,
+                fn:count($uris)
+            )
+
+    let $results-by-uri := map:map()
+    let $_ :=
+        for $result in $page-response/search:result
+        return map:put($results-by-uri, xs:string($result/@uri), $result)
+
+    let $ordered-results :=
+        for $uri at $i in $uris
+        let $result := map:get($results-by-uri, $uri)
+        return
+            if (fn:empty($result)) then
+                ()
+            else
+                element { fn:node-name($result) } {
+                    $result/@*[fn:local-name(.) ne "index"],
+                    attribute index { $start + $i - 1 },
+                    $result/node()
+                }
+
+    return
+        element { fn:QName("http://marklogic.com/appservices/search", "response") } {
+            attribute total { $total },
+            attribute start { $start },
+            attribute page-length { fn:count($ordered-results) },
+            $page-response/@snippet-format,
+            $facets-response/search:facet,
+            $ordered-results,
+            $page-response/search:metrics
+        }
+};
+
+(: One property-index read for the page (not per-URI round trips in XQuery). :)
+declare function hydrate-identifiers($uris as xs:string*) as map:map {
+    let $identifier-map := map:map()
+    let $existing as xs:string* :=
+        for $uri in $uris
+        where fn:doc-available($uri)
+        return $uri
+    return
+        if (fn:empty($existing)) then
+            $identifier-map
+        else
+            let $props := xdmp:document-get-properties($existing, xs:QName("identifiers"))
+            let $_ :=
+                for $prop in $props
+                return map:put($identifier-map, xdmp:node-uri($prop), $prop)
+            return $identifier-map
+};
+
+(: Attach search:extracted kind="identifiers" on every result; preserve body extracts. :)
+declare function amalgamate-identifiers($search-results, $identifier-map as map:map) {
     if (fn:empty($search-results)) then
         $search-results
     else
-    let $result-uris := $search-results//search:result/@uri
-
-    (: get a map of uri: identifiers for insertion later :)
-    let $identifiers := xdmp:document-get-properties($result-uris, xs:QName("identifiers"))
-    let $identifier-map := map:map()
-    let $_ := for $uri in $result-uris return map:put($identifier-map, $uri, xdmp:document-get-properties($uri, xs:QName("identifiers")))
-
-    let $params := map:new(
-        map:entry(xdmp:key-from-QName(fn:QName("", "identifier-map")), $identifier-map)
-    )
-    let $merge-properties :=
-        <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-            xmlns:search="http://marklogic.com/appservices/search"
-            xmlns:map="http://marklogic.com/xdmp/map">
-            <xsl:param name="identifier-map"/>
-            <xsl:template match="/ | @* | node()">
-                <xsl:copy>
-                    <xsl:apply-templates select="@* | node()" />
-                </xsl:copy>
-            </xsl:template>
-            <xsl:template match="search:extracted">
-                <!-- Copy the element -->
-                <xsl:copy>
-                    <!-- And everything inside it -->
-                    <xsl:apply-templates select="@* | node()"/>
-                </xsl:copy>
-                <!-- Add new node -->
-                <xsl:variable name="uri" select="ancestor::search:result/@uri"/>
-                <search:extracted kind="identifiers"><xsl:copy-of select="map:get($identifier-map, $uri)"/></search:extracted>
-            </xsl:template>
-        </xsl:stylesheet>
-
-
-    return xdmp:xslt-eval($merge-properties, $search-results, $params)
+        let $params := map:new(
+            map:entry(xdmp:key-from-QName(fn:QName("", "identifier-map")), $identifier-map)
+        )
+        let $merge :=
+            <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:search="http://marklogic.com/appservices/search"
+                xmlns:map="http://marklogic.com/xdmp/map">
+                <xsl:param name="identifier-map"/>
+                <xsl:template match="/ | @* | node()">
+                    <xsl:copy>
+                        <xsl:apply-templates select="@* | node()" />
+                    </xsl:copy>
+                </xsl:template>
+                <xsl:template match="search:result">
+                    <xsl:copy>
+                        <xsl:apply-templates select="@* | node()"/>
+                        <xsl:variable name="uri" select="string(@uri)"/>
+                        <search:extracted kind="identifiers">
+                            <xsl:copy-of select="map:get($identifier-map, $uri)"/>
+                        </search:extracted>
+                    </xsl:copy>
+                </xsl:template>
+            </xsl:stylesheet>
+        return xdmp:xslt-eval($merge, $search-results, $params)
 };

--- a/src/main/ml-modules/root/judgments/search/search-v2.xqy
+++ b/src/main/ml-modules/root/judgments/search/search-v2.xqy
@@ -1,6 +1,5 @@
 xquery version "1.0-ml";
 
-import module namespace search = "http://marklogic.com/appservices/search" at "/MarkLogic/appservices/search/search.xqy";
 import module namespace helper = "https://caselaw.nationalarchives.gov.uk/helper" at "/judgments/search/helper.xqy";
 import module namespace dls = "http://marklogic.com/xdmp/dls" at "/MarkLogic/dls.xqy";
 
@@ -209,14 +208,12 @@ let $boosted-query := helper:boost-title-and-ncn($q, $query)
 
 let $show-snippets as xs:boolean := exists(( $q-query, $party-query, $judge-query ))
 
+(: Build document options once. date/transformation sort-order live here;
+   order=updated branches inside resolve-paged-search (properties index-order). :)
 let $sort-order := if ($sort-word = 'date') then
     <sort-order xmlns="http://marklogic.com/appservices/search" type="xs:date" direction="{$sort-direction}">
             <path-index xmlns:akn="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">akn:judgment/akn:meta/akn:identification/akn:FRBRWork/akn:FRBRdate/@date</path-index>
         </sort-order>
-else if ($sort-word = 'updated') then
-    <sort-order xmlns="http://marklogic.com/appservices/search" direction="{$sort-direction}" type="xs:dateTime">
-        <element ns="http://marklogic.com/xdmp/property" name="last-modified" />
-    </sort-order>
 else if ($sort-word = 'transformation') then
     <sort-order xmlns="http://marklogic.com/appservices/search" type="xs:dateTime" direction="{$sort-direction}">
         <path-index xmlns:akn="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">akn:akomaNtoso/akn:judgment/akn:meta/akn:identification/akn:FRBRManifestation/akn:FRBRdate[@name='transform']/@date</path-index>
@@ -229,12 +226,8 @@ let $transform-results := if ($show-snippets) then
 else
     <transform-results xmlns="http://marklogic.com/appservices/search" apply="empty-snippet" />
 
-(: last-modified lives on the properties fragment; sorting by it requires
-   properties scope. Document extracts are still filled via URI after resolve. :)
-let $scope := if ($sort-word = 'updated') then 'properties' else 'documents'
-
-let $search-options := <options xmlns="http://marklogic.com/appservices/search">
-    <fragment-scope>{ $scope }</fragment-scope>
+let $document-options := <options xmlns="http://marklogic.com/appservices/search">
+    <fragment-scope>documents</fragment-scope>
     <search-option>unfiltered</search-option>
     <constraint name="court">
         <range type="xs:string" facet="true">
@@ -264,14 +257,11 @@ let $search-options := <options xmlns="http://marklogic.com/appservices/search">
     { $transform-results }
 </options>
 
-(: With properties fragment-scope, constrain on document content via
-   document-fragment-query so text/filters still apply to the judgment XML. :)
-let $resolve-query := if ($sort-word = 'updated') then
-    cts:document-fragment-query($boosted-query)
-else
-    $boosted-query
-
-(: Execute the search :)
-let $results := search:resolve(element x { $resolve-query }/*, $search-options, $start, $page-size)
-
-return helper:add-properties-to-search($results)
+return helper:resolve-paged-search(
+    $boosted-query,
+    $sort-word,
+    $sort-direction,
+    $start,
+    $page-size,
+    $document-options
+)

--- a/src/test/ml-modules/root/test/suites/SearchCombined/keyword-court-order-tests.xqy
+++ b/src/test/ml-modules/root/test/suites/SearchCombined/keyword-court-order-tests.xqy
@@ -1,0 +1,68 @@
+xquery version '1.0-ml';
+
+import module namespace test = 'http://marklogic.com/test' at '/test/test-helper.xqy';
+import module namespace search = "http://marklogic.com/appservices/search" at "/MarkLogic/appservices/search/search.xqy";
+import module namespace search-test = "https://caselaw.nationalarchives.gov.uk/test/search" at "/test/lib/search-test-helper.xqy";
+import module namespace json = "http://marklogic.com/xdmp/json" at "/MarkLogic/json/json.xqy";
+
+declare namespace akn = "http://docs.oasis-open.org/legaldocml/ns/akn/3.0";
+declare namespace uk = "https://caselaw.nationalarchives.gov.uk/akn";
+
+(: Keyword + court filter + order, for both document-sortable and updated paths. :)
+
+declare function local:uris($response) as xs:string* {
+  for $r in $response//search:result return string($r/@uri)
+};
+
+declare function local:search($order as xs:string) {
+  search-test:search(
+    map:entry("q", "combinedfixture")
+      => map:with("court", json:to-array("EWHC-Chancery"))
+      => map:with("order", $order)
+  )
+};
+
+declare function local:assert-metadata($response) {
+  let $results := $response//search:result
+  let $element-extracts := $results/search:extracted[(not(@kind) or @kind = "element")]
+  return (
+    test:assert-equal("2", string($response//@total)),
+    test:assert-equal(2, fn:count($results)),
+    test:assert-true(fn:not(local:uris($response) = "/combined/fam-2020.xml")),
+    test:assert-equal(0, fn:count($results/search:extracted-none)),
+    test:assert-equal(2, fn:count($element-extracts)),
+    test:assert-equal(2, fn:count($element-extracts//akn:FRBRname/@value)),
+    test:assert-equal(2, fn:count($element-extracts//uk:court)),
+    test:assert-equal(2, fn:count($results/search:extracted[@kind="identifiers"])),
+    test:assert-equal(2, fn:count($results/search:extracted[@kind="identifiers"]/identifiers/identifier))
+  )
+};
+
+let $date-asc := local:search("date")
+let $date-desc := local:search("-date")
+let $updated-asc := local:search("updated")
+let $updated-desc := local:search("-updated")
+
+let $date-asc-uris := local:uris($date-asc)
+let $date-desc-uris := local:uris($date-desc)
+let $updated-asc-uris := local:uris($updated-asc)
+let $updated-desc-uris := local:uris($updated-desc)
+
+return (
+  local:assert-metadata($date-asc),
+  test:assert-equal("/combined/ch-2020.xml", $date-asc-uris[1]),
+  test:assert-equal("/combined/ch-2022.xml", $date-asc-uris[2]),
+
+  local:assert-metadata($date-desc),
+  test:assert-equal("/combined/ch-2022.xml", $date-desc-uris[1]),
+  test:assert-equal("/combined/ch-2020.xml", $date-desc-uris[2]),
+
+  (: setup.xqy: ch-2022 touched first → oldest last-modified. :)
+  local:assert-metadata($updated-asc),
+  test:assert-equal("/combined/ch-2022.xml", $updated-asc-uris[1]),
+  test:assert-equal("/combined/ch-2020.xml", $updated-asc-uris[2]),
+
+  local:assert-metadata($updated-desc),
+  test:assert-equal("/combined/ch-2020.xml", $updated-desc-uris[1]),
+  test:assert-equal("/combined/ch-2022.xml", $updated-desc-uris[2])
+)

--- a/src/test/ml-modules/root/test/suites/SearchCombined/setup.xqy
+++ b/src/test/ml-modules/root/test/suites/SearchCombined/setup.xqy
@@ -1,0 +1,25 @@
+xquery version '1.0-ml';
+
+import module namespace test = 'http://marklogic.com/test' at '/test/test-helper.xqy';
+
+(: Distinct prop:last-modified before each test. Chancery 2022 touched first
+   (oldest last-modified), then 2020 (newer). Family is touched last but is
+   excluded by the court filter in the combined tests. :)
+declare function local:touch($uri as xs:string) {
+  xdmp:eval(
+    'declare variable $uri as xs:string external;
+     xdmp:document-set-property($uri, <updated-touch>{xdmp:request-timestamp()}</updated-touch>)',
+    map:map() => map:with("uri", $uri),
+    <options xmlns="xdmp:eval">
+      <isolation>different-transaction</isolation>
+      <update>true</update>
+    </options>
+  )
+};
+
+let $_ := local:touch("/combined/ch-2022.xml")
+let $_ := xdmp:sleep(1100)
+let $_ := local:touch("/combined/ch-2020.xml")
+let $_ := xdmp:sleep(1100)
+let $_ := local:touch("/combined/fam-2020.xml")
+return test:log("SearchCombined per-test last-modified setup COMPLETE....")

--- a/src/test/ml-modules/root/test/suites/SearchCombined/suite-setup.xqy
+++ b/src/test/ml-modules/root/test/suites/SearchCombined/suite-setup.xqy
@@ -1,0 +1,50 @@
+xquery version '1.0-ml';
+
+import module namespace test = 'http://marklogic.com/test' at '/test/test-helper.xqy';
+import module namespace dls = "http://marklogic.com/xdmp/dls" at "/MarkLogic/dls.xqy";
+
+declare function local:publish-judgment($uri as xs:string, $fclid as xs:string, $slug as xs:string) as empty-sequence() {
+  if (fn:not(dls:document-is-managed($uri))) then
+    dls:document-manage($uri, fn:true())
+  else (),
+  dls:document-set-permissions(
+    $uri,
+    (
+      xdmp:permission("caselaw-reader", "read"),
+      xdmp:permission("caselaw-reader", "update"),
+      xdmp:permission("dls-user", "read"),
+      xdmp:permission("dls-user", "update")
+    )
+  ),
+  xdmp:document-add-properties(
+    $uri,
+    (
+      <published>true</published>,
+      <identifiers>
+        <identifier>
+          <namespace>fclid</namespace>
+          <uuid>id-{$fclid}</uuid>
+          <value>{$fclid}</value>
+          <url_slug>{$slug}</url_slug>
+        </identifier>
+      </identifiers>
+    )
+  ),
+  xdmp:document-add-collections($uri, "judgment")
+};
+
+let $collections := ("judgments", "judgment", "http://marklogic.com/collections/dls/latest-version")
+
+let $_ := test:load-test-file("combined-ch-2020.xml", xdmp:database(), "/combined/ch-2020.xml")
+let $_ := xdmp:document-set-collections("/combined/ch-2020.xml", $collections)
+let $_ := local:publish-judgment("/combined/ch-2020.xml", "cmbch20a", "combined/ch-2020")
+
+let $_ := test:load-test-file("combined-ch-2022.xml", xdmp:database(), "/combined/ch-2022.xml")
+let $_ := xdmp:document-set-collections("/combined/ch-2022.xml", $collections)
+let $_ := local:publish-judgment("/combined/ch-2022.xml", "cmbch22b", "combined/ch-2022")
+
+let $_ := test:load-test-file("combined-fam-2020.xml", xdmp:database(), "/combined/fam-2020.xml")
+let $_ := xdmp:document-set-collections("/combined/fam-2020.xml", $collections)
+let $_ := local:publish-judgment("/combined/fam-2020.xml", "cmbfam0c", "combined/fam-2020")
+
+return test:log("SearchCombined Suite Setup COMPLETE....")

--- a/src/test/ml-modules/root/test/suites/SearchCombined/suite-teardown.xqy
+++ b/src/test/ml-modules/root/test/suites/SearchCombined/suite-teardown.xqy
@@ -1,0 +1,6 @@
+xquery version '1.0-ml';
+
+import module namespace test = 'http://marklogic.com/test' at '/test/test-helper.xqy';
+
+for $doc in doc()
+return xdmp:document-delete(xdmp:node-uri($doc))

--- a/src/test/ml-modules/root/test/suites/SearchCombined/test-data/combined-ch-2020.xml
+++ b/src/test/ml-modules/root/test/suites/SearchCombined/test-data/combined-ch-2020.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
+  <judgment name="decision">
+    <meta>
+      <identification source="#tna">
+        <FRBRWork>
+          <FRBRthis value="https://caselaw.nationalarchives.gov.uk/id/combined/ch-2020"/>
+          <FRBRuri value="https://caselaw.nationalarchives.gov.uk/id/combined/ch-2020"/>
+          <FRBRdate date="2020-06-01" name="decision"/>
+          <FRBRauthor href="#"/>
+          <FRBRcountry value="GB-UKM"/>
+          <FRBRnumber value=""/>
+          <FRBRname value="Combined Chancery 2020"/>
+        </FRBRWork>
+        <FRBRExpression>
+          <FRBRthis value="https://caselaw.nationalarchives.gov.uk/combined/ch-2020"/>
+          <FRBRuri value="https://caselaw.nationalarchives.gov.uk/combined/ch-2020"/>
+          <FRBRdate date="2020-06-01" name="decision"/>
+          <FRBRauthor href="#"/>
+          <FRBRlanguage language="eng"/>
+        </FRBRExpression>
+        <FRBRManifestation>
+          <FRBRthis value="https://caselaw.nationalarchives.gov.uk/combined/ch-2020/data.xml"/>
+          <FRBRuri value="https://caselaw.nationalarchives.gov.uk/combined/ch-2020/data.xml"/>
+          <FRBRdate date="2020-06-01T10:00:00" name="transform"/>
+          <FRBRauthor href="#tna"/>
+          <FRBRformat value="application/xml"/>
+        </FRBRManifestation>
+      </identification>
+      <proprietary source="#">
+        <uk:cite>[2020] EWHC 200 (Ch)</uk:cite>
+        <uk:court>EWHC-Chancery</uk:court>
+      </proprietary>
+    </meta>
+    <header>
+      <p>combined chancery 2020</p>
+    </header>
+    <judgmentBody>
+      <decision>
+        <p>unique keyword for combined tests: combinedfixture</p>
+      </decision>
+    </judgmentBody>
+  </judgment>
+</akomaNtoso>

--- a/src/test/ml-modules/root/test/suites/SearchCombined/test-data/combined-ch-2022.xml
+++ b/src/test/ml-modules/root/test/suites/SearchCombined/test-data/combined-ch-2022.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
+  <judgment name="decision">
+    <meta>
+      <identification source="#tna">
+        <FRBRWork>
+          <FRBRthis value="https://caselaw.nationalarchives.gov.uk/id/combined/ch-2022"/>
+          <FRBRuri value="https://caselaw.nationalarchives.gov.uk/id/combined/ch-2022"/>
+          <FRBRdate date="2022-06-01" name="decision"/>
+          <FRBRauthor href="#"/>
+          <FRBRcountry value="GB-UKM"/>
+          <FRBRnumber value=""/>
+          <FRBRname value="Combined Chancery 2022"/>
+        </FRBRWork>
+        <FRBRExpression>
+          <FRBRthis value="https://caselaw.nationalarchives.gov.uk/combined/ch-2022"/>
+          <FRBRuri value="https://caselaw.nationalarchives.gov.uk/combined/ch-2022"/>
+          <FRBRdate date="2022-06-01" name="decision"/>
+          <FRBRauthor href="#"/>
+          <FRBRlanguage language="eng"/>
+        </FRBRExpression>
+        <FRBRManifestation>
+          <FRBRthis value="https://caselaw.nationalarchives.gov.uk/combined/ch-2022/data.xml"/>
+          <FRBRuri value="https://caselaw.nationalarchives.gov.uk/combined/ch-2022/data.xml"/>
+          <FRBRdate date="2022-06-01T10:00:00" name="transform"/>
+          <FRBRauthor href="#tna"/>
+          <FRBRformat value="application/xml"/>
+        </FRBRManifestation>
+      </identification>
+      <proprietary source="#">
+        <uk:cite>[2022] EWHC 200 (Ch)</uk:cite>
+        <uk:court>EWHC-Chancery</uk:court>
+      </proprietary>
+    </meta>
+    <header>
+      <p>combined chancery 2022</p>
+    </header>
+    <judgmentBody>
+      <decision>
+        <p>unique keyword for combined tests: combinedfixture</p>
+      </decision>
+    </judgmentBody>
+  </judgment>
+</akomaNtoso>

--- a/src/test/ml-modules/root/test/suites/SearchCombined/test-data/combined-fam-2020.xml
+++ b/src/test/ml-modules/root/test/suites/SearchCombined/test-data/combined-fam-2020.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
+  <judgment name="decision">
+    <meta>
+      <identification source="#tna">
+        <FRBRWork>
+          <FRBRthis value="https://caselaw.nationalarchives.gov.uk/id/combined/fam-2020"/>
+          <FRBRuri value="https://caselaw.nationalarchives.gov.uk/id/combined/fam-2020"/>
+          <FRBRdate date="2020-06-01" name="decision"/>
+          <FRBRauthor href="#"/>
+          <FRBRcountry value="GB-UKM"/>
+          <FRBRnumber value=""/>
+          <FRBRname value="Combined Family 2020"/>
+        </FRBRWork>
+        <FRBRExpression>
+          <FRBRthis value="https://caselaw.nationalarchives.gov.uk/combined/fam-2020"/>
+          <FRBRuri value="https://caselaw.nationalarchives.gov.uk/combined/fam-2020"/>
+          <FRBRdate date="2020-06-01" name="decision"/>
+          <FRBRauthor href="#"/>
+          <FRBRlanguage language="eng"/>
+        </FRBRExpression>
+        <FRBRManifestation>
+          <FRBRthis value="https://caselaw.nationalarchives.gov.uk/combined/fam-2020/data.xml"/>
+          <FRBRuri value="https://caselaw.nationalarchives.gov.uk/combined/fam-2020/data.xml"/>
+          <FRBRdate date="2020-06-01T10:00:00" name="transform"/>
+          <FRBRauthor href="#tna"/>
+          <FRBRformat value="application/xml"/>
+        </FRBRManifestation>
+      </identification>
+      <proprietary source="#">
+        <uk:cite>[2020] EWHC 200 (Fam)</uk:cite>
+        <uk:court>EWHC-Family</uk:court>
+      </proprietary>
+    </meta>
+    <header>
+      <p>combined family 2020</p>
+    </header>
+    <judgmentBody>
+      <decision>
+        <p>unique keyword for combined tests: combinedfixture</p>
+      </decision>
+    </judgmentBody>
+  </judgment>
+</akomaNtoso>

--- a/src/test/ml-modules/root/test/suites/SearchFilters/court-tests.xqy
+++ b/src/test/ml-modules/root/test/suites/SearchFilters/court-tests.xqy
@@ -1,0 +1,33 @@
+xquery version '1.0-ml';
+
+import module namespace test = 'http://marklogic.com/test' at '/test/test-helper.xqy';
+import module namespace search = "http://marklogic.com/appservices/search" at "/MarkLogic/appservices/search/search.xqy";
+import module namespace search-test = "https://caselaw.nationalarchives.gov.uk/test/search" at "/test/lib/search-test-helper.xqy";
+import module namespace json = "http://marklogic.com/xdmp/json" at "/MarkLogic/json/json.xqy";
+
+declare function local:uris($response) as xs:string* {
+  for $r in $response//search:result return string($r/@uri)
+};
+
+declare function local:search-with-court($court as xs:string) {
+  search-test:search(
+    map:entry("q", "filterfixture")
+      => map:with("court", json:to-array($court))
+  )
+};
+
+let $chancery := local:search-with-court("EWHC-Chancery")
+let $chancery-uris := local:uris($chancery)
+
+let $family := local:search-with-court("EWHC-Family")
+let $family-uris := local:uris($family)
+
+return (
+  test:assert-equal("2", string($chancery//@total)),
+  test:assert-true($chancery-uris = "/filter/ch-2020.xml"),
+  test:assert-true($chancery-uris = "/filter/ch-2022.xml"),
+  test:assert-true(fn:not($chancery-uris = "/filter/fam-2020.xml")),
+
+  test:assert-equal("1", string($family//@total)),
+  test:assert-equal("/filter/fam-2020.xml", $family-uris[1])
+)

--- a/src/test/ml-modules/root/test/suites/SearchFilters/date-range-tests.xqy
+++ b/src/test/ml-modules/root/test/suites/SearchFilters/date-range-tests.xqy
@@ -1,0 +1,45 @@
+xquery version '1.0-ml';
+
+import module namespace test = 'http://marklogic.com/test' at '/test/test-helper.xqy';
+import module namespace search = "http://marklogic.com/appservices/search" at "/MarkLogic/appservices/search/search.xqy";
+import module namespace search-test = "https://caselaw.nationalarchives.gov.uk/test/search" at "/test/lib/search-test-helper.xqy";
+import module namespace json = "http://marklogic.com/xdmp/json" at "/MarkLogic/json/json.xqy";
+
+declare function local:uris($response) as xs:string* {
+  for $r in $response//search:result return string($r/@uri)
+};
+
+let $year-2020 := search-test:search(
+  map:entry("q", "filterfixture")
+    => map:with("from", "2020-01-01")
+    => map:with("to", "2020-12-31")
+)
+let $year-2020-uris := local:uris($year-2020)
+
+let $year-2022 := search-test:search(
+  map:entry("q", "filterfixture")
+    => map:with("from", "2022-01-01")
+    => map:with("to", "2022-12-31")
+)
+let $year-2022-uris := local:uris($year-2022)
+
+let $chancery-2020 := search-test:search(
+  map:entry("q", "filterfixture")
+    => map:with("court", json:to-array("EWHC-Chancery"))
+    => map:with("from", "2020-01-01")
+    => map:with("to", "2020-12-31")
+)
+let $chancery-2020-uris := local:uris($chancery-2020)
+
+return (
+  test:assert-equal("2", string($year-2020//@total)),
+  test:assert-true($year-2020-uris = "/filter/ch-2020.xml"),
+  test:assert-true($year-2020-uris = "/filter/fam-2020.xml"),
+  test:assert-true(fn:not($year-2020-uris = "/filter/ch-2022.xml")),
+
+  test:assert-equal("1", string($year-2022//@total)),
+  test:assert-equal("/filter/ch-2022.xml", $year-2022-uris[1]),
+
+  test:assert-equal("1", string($chancery-2020//@total)),
+  test:assert-equal("/filter/ch-2020.xml", $chancery-2020-uris[1])
+)

--- a/src/test/ml-modules/root/test/suites/SearchFilters/suite-setup.xqy
+++ b/src/test/ml-modules/root/test/suites/SearchFilters/suite-setup.xqy
@@ -1,0 +1,37 @@
+xquery version '1.0-ml';
+
+import module namespace test = 'http://marklogic.com/test' at '/test/test-helper.xqy';
+import module namespace dls = "http://marklogic.com/xdmp/dls" at "/MarkLogic/dls.xqy";
+
+declare function local:publish-judgment($uri as xs:string) as empty-sequence() {
+  if (fn:not(dls:document-is-managed($uri))) then
+    dls:document-manage($uri, fn:true())
+  else (),
+  dls:document-set-permissions(
+    $uri,
+    (
+      xdmp:permission("caselaw-reader", "read"),
+      xdmp:permission("caselaw-reader", "update"),
+      xdmp:permission("dls-user", "read"),
+      xdmp:permission("dls-user", "update")
+    )
+  ),
+  xdmp:document-add-properties($uri, <published>true</published>),
+  xdmp:document-add-collections($uri, "judgment")
+};
+
+let $collections := ("judgments", "judgment", "http://marklogic.com/collections/dls/latest-version")
+
+let $_ := test:load-test-file("filter-ch-2020.xml", xdmp:database(), "/filter/ch-2020.xml")
+let $_ := xdmp:document-set-collections("/filter/ch-2020.xml", $collections)
+let $_ := local:publish-judgment("/filter/ch-2020.xml")
+
+let $_ := test:load-test-file("filter-fam-2020.xml", xdmp:database(), "/filter/fam-2020.xml")
+let $_ := xdmp:document-set-collections("/filter/fam-2020.xml", $collections)
+let $_ := local:publish-judgment("/filter/fam-2020.xml")
+
+let $_ := test:load-test-file("filter-ch-2022.xml", xdmp:database(), "/filter/ch-2022.xml")
+let $_ := xdmp:document-set-collections("/filter/ch-2022.xml", $collections)
+let $_ := local:publish-judgment("/filter/ch-2022.xml")
+
+return test:log("SearchFilters Suite Setup COMPLETE....")

--- a/src/test/ml-modules/root/test/suites/SearchFilters/suite-teardown.xqy
+++ b/src/test/ml-modules/root/test/suites/SearchFilters/suite-teardown.xqy
@@ -1,0 +1,6 @@
+xquery version '1.0-ml';
+
+import module namespace test = 'http://marklogic.com/test' at '/test/test-helper.xqy';
+
+for $doc in doc()
+return xdmp:document-delete(xdmp:node-uri($doc))

--- a/src/test/ml-modules/root/test/suites/SearchFilters/test-data/filter-ch-2020.xml
+++ b/src/test/ml-modules/root/test/suites/SearchFilters/test-data/filter-ch-2020.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
+  <judgment name="decision">
+    <meta>
+      <identification source="#tna">
+        <FRBRWork>
+          <FRBRthis value="https://caselaw.nationalarchives.gov.uk/id/filter/ch-2020"/>
+          <FRBRuri value="https://caselaw.nationalarchives.gov.uk/id/filter/ch-2020"/>
+          <FRBRdate date="2020-06-01" name="decision"/>
+          <FRBRauthor href="#"/>
+          <FRBRcountry value="GB-UKM"/>
+          <FRBRnumber value=""/>
+          <FRBRname value="Filter Chancery 2020 Fixture"/>
+        </FRBRWork>
+        <FRBRExpression>
+          <FRBRthis value="https://caselaw.nationalarchives.gov.uk/filter/ch-2020"/>
+          <FRBRuri value="https://caselaw.nationalarchives.gov.uk/filter/ch-2020"/>
+          <FRBRdate date="2020-06-01" name="decision"/>
+          <FRBRauthor href="#"/>
+          <FRBRlanguage language="eng"/>
+        </FRBRExpression>
+        <FRBRManifestation>
+          <FRBRthis value="https://caselaw.nationalarchives.gov.uk/filter/ch-2020/data.xml"/>
+          <FRBRuri value="https://caselaw.nationalarchives.gov.uk/filter/ch-2020/data.xml"/>
+          <FRBRdate date="2020-06-01T10:00:00" name="transform"/>
+          <FRBRauthor href="#tna"/>
+          <FRBRformat value="application/xml"/>
+        </FRBRManifestation>
+      </identification>
+      <proprietary source="#">
+        <uk:cite>[2020] EWHC 100 (Ch)</uk:cite>
+        <uk:court>EWHC-Chancery</uk:court>
+      </proprietary>
+    </meta>
+    <header>
+      <p>filter chancery 2020 fixture</p>
+    </header>
+    <judgmentBody>
+      <decision>
+        <p>unique keyword for filter tests: filterfixture</p>
+      </decision>
+    </judgmentBody>
+  </judgment>
+</akomaNtoso>

--- a/src/test/ml-modules/root/test/suites/SearchFilters/test-data/filter-ch-2022.xml
+++ b/src/test/ml-modules/root/test/suites/SearchFilters/test-data/filter-ch-2022.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
+  <judgment name="decision">
+    <meta>
+      <identification source="#tna">
+        <FRBRWork>
+          <FRBRthis value="https://caselaw.nationalarchives.gov.uk/id/filter/ch-2022"/>
+          <FRBRuri value="https://caselaw.nationalarchives.gov.uk/id/filter/ch-2022"/>
+          <FRBRdate date="2022-06-01" name="decision"/>
+          <FRBRauthor href="#"/>
+          <FRBRcountry value="GB-UKM"/>
+          <FRBRnumber value=""/>
+          <FRBRname value="Filter Chancery 2022 Fixture"/>
+        </FRBRWork>
+        <FRBRExpression>
+          <FRBRthis value="https://caselaw.nationalarchives.gov.uk/filter/ch-2022"/>
+          <FRBRuri value="https://caselaw.nationalarchives.gov.uk/filter/ch-2022"/>
+          <FRBRdate date="2022-06-01" name="decision"/>
+          <FRBRauthor href="#"/>
+          <FRBRlanguage language="eng"/>
+        </FRBRExpression>
+        <FRBRManifestation>
+          <FRBRthis value="https://caselaw.nationalarchives.gov.uk/filter/ch-2022/data.xml"/>
+          <FRBRuri value="https://caselaw.nationalarchives.gov.uk/filter/ch-2022/data.xml"/>
+          <FRBRdate date="2022-06-01T10:00:00" name="transform"/>
+          <FRBRauthor href="#tna"/>
+          <FRBRformat value="application/xml"/>
+        </FRBRManifestation>
+      </identification>
+      <proprietary source="#">
+        <uk:cite>[2022] EWHC 100 (Ch)</uk:cite>
+        <uk:court>EWHC-Chancery</uk:court>
+      </proprietary>
+    </meta>
+    <header>
+      <p>filter chancery 2022 fixture</p>
+    </header>
+    <judgmentBody>
+      <decision>
+        <p>unique keyword for filter tests: filterfixture</p>
+      </decision>
+    </judgmentBody>
+  </judgment>
+</akomaNtoso>

--- a/src/test/ml-modules/root/test/suites/SearchFilters/test-data/filter-fam-2020.xml
+++ b/src/test/ml-modules/root/test/suites/SearchFilters/test-data/filter-fam-2020.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
+  <judgment name="decision">
+    <meta>
+      <identification source="#tna">
+        <FRBRWork>
+          <FRBRthis value="https://caselaw.nationalarchives.gov.uk/id/filter/fam-2020"/>
+          <FRBRuri value="https://caselaw.nationalarchives.gov.uk/id/filter/fam-2020"/>
+          <FRBRdate date="2020-06-01" name="decision"/>
+          <FRBRauthor href="#"/>
+          <FRBRcountry value="GB-UKM"/>
+          <FRBRnumber value=""/>
+          <FRBRname value="Filter Family 2020 Fixture"/>
+        </FRBRWork>
+        <FRBRExpression>
+          <FRBRthis value="https://caselaw.nationalarchives.gov.uk/filter/fam-2020"/>
+          <FRBRuri value="https://caselaw.nationalarchives.gov.uk/filter/fam-2020"/>
+          <FRBRdate date="2020-06-01" name="decision"/>
+          <FRBRauthor href="#"/>
+          <FRBRlanguage language="eng"/>
+        </FRBRExpression>
+        <FRBRManifestation>
+          <FRBRthis value="https://caselaw.nationalarchives.gov.uk/filter/fam-2020/data.xml"/>
+          <FRBRuri value="https://caselaw.nationalarchives.gov.uk/filter/fam-2020/data.xml"/>
+          <FRBRdate date="2020-06-01T10:00:00" name="transform"/>
+          <FRBRauthor href="#tna"/>
+          <FRBRformat value="application/xml"/>
+        </FRBRManifestation>
+      </identification>
+      <proprietary source="#">
+        <uk:cite>[2020] EWHC 100 (Fam)</uk:cite>
+        <uk:court>EWHC-Family</uk:court>
+      </proprietary>
+    </meta>
+    <header>
+      <p>filter family 2020 fixture</p>
+    </header>
+    <judgmentBody>
+      <decision>
+        <p>unique keyword for filter tests: filterfixture</p>
+      </decision>
+    </judgmentBody>
+  </judgment>
+</akomaNtoso>

--- a/src/test/ml-modules/root/test/suites/SearchOrder/order-by-updated-public-ui-tests.xqy
+++ b/src/test/ml-modules/root/test/suites/SearchOrder/order-by-updated-public-ui-tests.xqy
@@ -14,8 +14,8 @@ declare function local:search-as-public-ui($order as xs:string) {
 let $date-ascending := local:search-as-public-ui("date")
 let $date-ascending-uris := for $r in $date-ascending//search:result return string($r/@uri)
 
-(: Updated sort uses properties fragment-scope and prop:last-modified — the path
-   the Public UI reader account uses in production (tested via caselaw-public-ui-test). :)
+(: Updated sort uses the last-modified range index under documents scope.
+   Exercises the Public UI reader surrogate (caselaw-public-ui-test). :)
 let $ascending := local:search-as-public-ui("updated")
 let $descending := local:search-as-public-ui("-updated")
 

--- a/src/test/ml-modules/root/test/suites/SearchOrder/order-case-insensitive-tests.xqy
+++ b/src/test/ml-modules/root/test/suites/SearchOrder/order-case-insensitive-tests.xqy
@@ -12,6 +12,11 @@ declare function local:uris($order as xs:string) as xs:string* {
   return string($r/@uri)
 };
 
+(: Four updated-order searches after SearchOrder's per-test touch/sleep setup
+   can exceed the 20s REST default on a slow CI host. Raise only this request
+   — do not bump the app-server default (that would apply in production). :)
+let $_ := xdmp:set-request-time-limit(60)
+
 let $updated := local:uris("updated")
 let $Updated := local:uris("Updated")
 let $desc := local:uris("-updated")

--- a/src/test/ml-modules/root/test/suites/SearchPagination/pagination-tests.xqy
+++ b/src/test/ml-modules/root/test/suites/SearchPagination/pagination-tests.xqy
@@ -1,0 +1,69 @@
+xquery version '1.0-ml';
+
+import module namespace test = 'http://marklogic.com/test' at '/test/test-helper.xqy';
+import module namespace search = "http://marklogic.com/appservices/search" at "/MarkLogic/appservices/search/search.xqy";
+import module namespace search-test = "https://caselaw.nationalarchives.gov.uk/test/search" at "/test/lib/search-test-helper.xqy";
+
+declare namespace akn = "http://docs.oasis-open.org/legaldocml/ns/akn/3.0";
+
+(: Six fixtures, page-size 2 — covers documents-scoped (date) and properties-
+   scoped (updated) paging, including an empty page past the end. :)
+
+declare function local:uris($response) as xs:string* {
+  for $r in $response//search:result return string($r/@uri)
+};
+
+declare function local:search($order as xs:string, $page as xs:integer) {
+  search-test:search(
+    map:entry("q", "paginationfixture")
+      => map:with("order", $order)
+      => map:with("page", $page)
+      => map:with("page-size", 2)
+  )
+};
+
+declare function local:assert-page(
+  $response,
+  $expected-start as xs:integer,
+  $expected-uris as xs:string*
+) {
+  let $results := $response//search:result
+  let $expected-count := fn:count($expected-uris)
+  return (
+    test:assert-equal("6", string($response//@total)),
+    test:assert-equal(string($expected-start), string($response//@start)),
+    test:assert-equal($expected-count, fn:count($results)),
+    test:assert-equal($expected-uris, local:uris($response)),
+    (: Documents-scoped resolve keeps requested page-length even past the end;
+       only assert @page-length when the page has results. :)
+    if ($expected-count gt 0) then
+      test:assert-equal(string($expected-count), string($response//@page-length))
+    else (),
+    test:assert-equal(0, fn:count($results/search:extracted-none)),
+    test:assert-equal($expected-count, fn:count($results/search:extracted[(not(@kind) or @kind = "element")]//akn:FRBRname/@value)),
+    test:assert-equal($expected-count, fn:count($results/search:extracted[@kind="identifiers"]/identifiers/identifier))
+  )
+};
+
+let $ordered := (
+  "/pagination/a.xml",
+  "/pagination/b.xml",
+  "/pagination/c.xml",
+  "/pagination/d.xml",
+  "/pagination/e.xml",
+  "/pagination/f.xml"
+)
+
+let $orders := ("date", "updated")
+
+let $page-assertions :=
+  for $order in $orders
+  return (
+    local:assert-page(local:search($order, 1), 1, $ordered[1 to 2]),
+    local:assert-page(local:search($order, 2), 3, $ordered[3 to 4]),
+    local:assert-page(local:search($order, 3), 5, $ordered[5 to 6]),
+    (: Past the end: total still 6, no results. :)
+    local:assert-page(local:search($order, 4), 7, ())
+  )
+
+return $page-assertions

--- a/src/test/ml-modules/root/test/suites/SearchPagination/setup.xqy
+++ b/src/test/ml-modules/root/test/suites/SearchPagination/setup.xqy
@@ -1,0 +1,30 @@
+xquery version '1.0-ml';
+
+import module namespace test = 'http://marklogic.com/test' at '/test/test-helper.xqy';
+
+(: Distinct prop:last-modified before each test. Touch a→f so ascending
+   updated order matches decision-date order for these fixtures. :)
+declare function local:touch($uri as xs:string) {
+  xdmp:eval(
+    'declare variable $uri as xs:string external;
+     xdmp:document-set-property($uri, <updated-touch>{xdmp:request-timestamp()}</updated-touch>)',
+    map:map() => map:with("uri", $uri),
+    <options xmlns="xdmp:eval">
+      <isolation>different-transaction</isolation>
+      <update>true</update>
+    </options>
+  )
+};
+
+let $_ := local:touch("/pagination/a.xml")
+let $_ := xdmp:sleep(1100)
+let $_ := local:touch("/pagination/b.xml")
+let $_ := xdmp:sleep(1100)
+let $_ := local:touch("/pagination/c.xml")
+let $_ := xdmp:sleep(1100)
+let $_ := local:touch("/pagination/d.xml")
+let $_ := xdmp:sleep(1100)
+let $_ := local:touch("/pagination/e.xml")
+let $_ := xdmp:sleep(1100)
+let $_ := local:touch("/pagination/f.xml")
+return test:log("SearchPagination per-test last-modified setup COMPLETE....")

--- a/src/test/ml-modules/root/test/suites/SearchPagination/suite-setup.xqy
+++ b/src/test/ml-modules/root/test/suites/SearchPagination/suite-setup.xqy
@@ -1,0 +1,62 @@
+xquery version '1.0-ml';
+
+import module namespace test = 'http://marklogic.com/test' at '/test/test-helper.xqy';
+import module namespace dls = "http://marklogic.com/xdmp/dls" at "/MarkLogic/dls.xqy";
+
+declare function local:publish-judgment($uri as xs:string, $fclid as xs:string, $slug as xs:string) as empty-sequence() {
+  if (fn:not(dls:document-is-managed($uri))) then
+    dls:document-manage($uri, fn:true())
+  else (),
+  dls:document-set-permissions(
+    $uri,
+    (
+      xdmp:permission("caselaw-reader", "read"),
+      xdmp:permission("caselaw-reader", "update"),
+      xdmp:permission("dls-user", "read"),
+      xdmp:permission("dls-user", "update")
+    )
+  ),
+  xdmp:document-add-properties(
+    $uri,
+    (
+      <published>true</published>,
+      <identifiers>
+        <identifier>
+          <namespace>fclid</namespace>
+          <uuid>id-{$fclid}</uuid>
+          <value>{$fclid}</value>
+          <url_slug>{$slug}</url_slug>
+        </identifier>
+      </identifiers>
+    )
+  ),
+  xdmp:document-add-collections($uri, "judgment")
+};
+
+let $collections := ("judgments", "judgment", "http://marklogic.com/collections/dls/latest-version")
+
+let $_ := test:load-test-file("page-a.xml", xdmp:database(), "/pagination/a.xml")
+let $_ := xdmp:document-set-collections("/pagination/a.xml", $collections)
+let $_ := local:publish-judgment("/pagination/a.xml", "pagea00a", "pagination/a")
+
+let $_ := test:load-test-file("page-b.xml", xdmp:database(), "/pagination/b.xml")
+let $_ := xdmp:document-set-collections("/pagination/b.xml", $collections)
+let $_ := local:publish-judgment("/pagination/b.xml", "pageb00b", "pagination/b")
+
+let $_ := test:load-test-file("page-c.xml", xdmp:database(), "/pagination/c.xml")
+let $_ := xdmp:document-set-collections("/pagination/c.xml", $collections)
+let $_ := local:publish-judgment("/pagination/c.xml", "pagec00c", "pagination/c")
+
+let $_ := test:load-test-file("page-d.xml", xdmp:database(), "/pagination/d.xml")
+let $_ := xdmp:document-set-collections("/pagination/d.xml", $collections)
+let $_ := local:publish-judgment("/pagination/d.xml", "paged00d", "pagination/d")
+
+let $_ := test:load-test-file("page-e.xml", xdmp:database(), "/pagination/e.xml")
+let $_ := xdmp:document-set-collections("/pagination/e.xml", $collections)
+let $_ := local:publish-judgment("/pagination/e.xml", "pagee00e", "pagination/e")
+
+let $_ := test:load-test-file("page-f.xml", xdmp:database(), "/pagination/f.xml")
+let $_ := xdmp:document-set-collections("/pagination/f.xml", $collections)
+let $_ := local:publish-judgment("/pagination/f.xml", "pagef00f", "pagination/f")
+
+return test:log("SearchPagination Suite Setup COMPLETE....")

--- a/src/test/ml-modules/root/test/suites/SearchPagination/suite-teardown.xqy
+++ b/src/test/ml-modules/root/test/suites/SearchPagination/suite-teardown.xqy
@@ -1,0 +1,6 @@
+xquery version '1.0-ml';
+
+import module namespace test = 'http://marklogic.com/test' at '/test/test-helper.xqy';
+
+for $doc in doc()
+return xdmp:document-delete(xdmp:node-uri($doc))

--- a/src/test/ml-modules/root/test/suites/SearchPagination/test-data/page-a.xml
+++ b/src/test/ml-modules/root/test/suites/SearchPagination/test-data/page-a.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
+  <judgment name="decision">
+    <meta>
+      <identification source="#tna">
+        <FRBRWork>
+          <FRBRthis value="https://caselaw.nationalarchives.gov.uk/id/pagination/a"/>
+          <FRBRuri value="https://caselaw.nationalarchives.gov.uk/id/pagination/a"/>
+          <FRBRdate date="2019-01-01" name="decision"/>
+          <FRBRauthor href="#"/>
+          <FRBRcountry value="GB-UKM"/>
+          <FRBRnumber value=""/>
+          <FRBRname value="Pagination a"/>
+        </FRBRWork>
+        <FRBRExpression>
+          <FRBRthis value="https://caselaw.nationalarchives.gov.uk/pagination/a"/>
+          <FRBRuri value="https://caselaw.nationalarchives.gov.uk/pagination/a"/>
+          <FRBRdate date="2019-01-01" name="decision"/>
+          <FRBRauthor href="#"/>
+          <FRBRlanguage language="eng"/>
+        </FRBRExpression>
+        <FRBRManifestation>
+          <FRBRthis value="https://caselaw.nationalarchives.gov.uk/pagination/a/data.xml"/>
+          <FRBRuri value="https://caselaw.nationalarchives.gov.uk/pagination/a/data.xml"/>
+          <FRBRdate date="2019-01-01T12:00:00" name="transform"/>
+          <FRBRauthor href="#tna"/>
+          <FRBRformat value="application/xml"/>
+        </FRBRManifestation>
+      </identification>
+      <proprietary source="#">
+        <uk:cite>[2019] EWHC 100 (Ch)</uk:cite>
+        <uk:court>EWHC-Chancery</uk:court>
+      </proprietary>
+    </meta>
+    <header>
+      <p>pagination a</p>
+    </header>
+    <judgmentBody>
+      <decision>
+        <p>unique keyword for pagination tests: paginationfixture</p>
+      </decision>
+    </judgmentBody>
+  </judgment>
+</akomaNtoso>

--- a/src/test/ml-modules/root/test/suites/SearchPagination/test-data/page-b.xml
+++ b/src/test/ml-modules/root/test/suites/SearchPagination/test-data/page-b.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
+  <judgment name="decision">
+    <meta>
+      <identification source="#tna">
+        <FRBRWork>
+          <FRBRthis value="https://caselaw.nationalarchives.gov.uk/id/pagination/b"/>
+          <FRBRuri value="https://caselaw.nationalarchives.gov.uk/id/pagination/b"/>
+          <FRBRdate date="2020-01-01" name="decision"/>
+          <FRBRauthor href="#"/>
+          <FRBRcountry value="GB-UKM"/>
+          <FRBRnumber value=""/>
+          <FRBRname value="Pagination b"/>
+        </FRBRWork>
+        <FRBRExpression>
+          <FRBRthis value="https://caselaw.nationalarchives.gov.uk/pagination/b"/>
+          <FRBRuri value="https://caselaw.nationalarchives.gov.uk/pagination/b"/>
+          <FRBRdate date="2020-01-01" name="decision"/>
+          <FRBRauthor href="#"/>
+          <FRBRlanguage language="eng"/>
+        </FRBRExpression>
+        <FRBRManifestation>
+          <FRBRthis value="https://caselaw.nationalarchives.gov.uk/pagination/b/data.xml"/>
+          <FRBRuri value="https://caselaw.nationalarchives.gov.uk/pagination/b/data.xml"/>
+          <FRBRdate date="2020-01-01T12:00:00" name="transform"/>
+          <FRBRauthor href="#tna"/>
+          <FRBRformat value="application/xml"/>
+        </FRBRManifestation>
+      </identification>
+      <proprietary source="#">
+        <uk:cite>[2020] EWHC 101 (Ch)</uk:cite>
+        <uk:court>EWHC-Chancery</uk:court>
+      </proprietary>
+    </meta>
+    <header>
+      <p>pagination b</p>
+    </header>
+    <judgmentBody>
+      <decision>
+        <p>unique keyword for pagination tests: paginationfixture</p>
+      </decision>
+    </judgmentBody>
+  </judgment>
+</akomaNtoso>

--- a/src/test/ml-modules/root/test/suites/SearchPagination/test-data/page-c.xml
+++ b/src/test/ml-modules/root/test/suites/SearchPagination/test-data/page-c.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
+  <judgment name="decision">
+    <meta>
+      <identification source="#tna">
+        <FRBRWork>
+          <FRBRthis value="https://caselaw.nationalarchives.gov.uk/id/pagination/c"/>
+          <FRBRuri value="https://caselaw.nationalarchives.gov.uk/id/pagination/c"/>
+          <FRBRdate date="2021-01-01" name="decision"/>
+          <FRBRauthor href="#"/>
+          <FRBRcountry value="GB-UKM"/>
+          <FRBRnumber value=""/>
+          <FRBRname value="Pagination c"/>
+        </FRBRWork>
+        <FRBRExpression>
+          <FRBRthis value="https://caselaw.nationalarchives.gov.uk/pagination/c"/>
+          <FRBRuri value="https://caselaw.nationalarchives.gov.uk/pagination/c"/>
+          <FRBRdate date="2021-01-01" name="decision"/>
+          <FRBRauthor href="#"/>
+          <FRBRlanguage language="eng"/>
+        </FRBRExpression>
+        <FRBRManifestation>
+          <FRBRthis value="https://caselaw.nationalarchives.gov.uk/pagination/c/data.xml"/>
+          <FRBRuri value="https://caselaw.nationalarchives.gov.uk/pagination/c/data.xml"/>
+          <FRBRdate date="2021-01-01T12:00:00" name="transform"/>
+          <FRBRauthor href="#tna"/>
+          <FRBRformat value="application/xml"/>
+        </FRBRManifestation>
+      </identification>
+      <proprietary source="#">
+        <uk:cite>[2021] EWHC 102 (Ch)</uk:cite>
+        <uk:court>EWHC-Chancery</uk:court>
+      </proprietary>
+    </meta>
+    <header>
+      <p>pagination c</p>
+    </header>
+    <judgmentBody>
+      <decision>
+        <p>unique keyword for pagination tests: paginationfixture</p>
+      </decision>
+    </judgmentBody>
+  </judgment>
+</akomaNtoso>

--- a/src/test/ml-modules/root/test/suites/SearchPagination/test-data/page-d.xml
+++ b/src/test/ml-modules/root/test/suites/SearchPagination/test-data/page-d.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
+  <judgment name="decision">
+    <meta>
+      <identification source="#tna">
+        <FRBRWork>
+          <FRBRthis value="https://caselaw.nationalarchives.gov.uk/id/pagination/d"/>
+          <FRBRuri value="https://caselaw.nationalarchives.gov.uk/id/pagination/d"/>
+          <FRBRdate date="2022-01-01" name="decision"/>
+          <FRBRauthor href="#"/>
+          <FRBRcountry value="GB-UKM"/>
+          <FRBRnumber value=""/>
+          <FRBRname value="Pagination d"/>
+        </FRBRWork>
+        <FRBRExpression>
+          <FRBRthis value="https://caselaw.nationalarchives.gov.uk/pagination/d"/>
+          <FRBRuri value="https://caselaw.nationalarchives.gov.uk/pagination/d"/>
+          <FRBRdate date="2022-01-01" name="decision"/>
+          <FRBRauthor href="#"/>
+          <FRBRlanguage language="eng"/>
+        </FRBRExpression>
+        <FRBRManifestation>
+          <FRBRthis value="https://caselaw.nationalarchives.gov.uk/pagination/d/data.xml"/>
+          <FRBRuri value="https://caselaw.nationalarchives.gov.uk/pagination/d/data.xml"/>
+          <FRBRdate date="2022-01-01T12:00:00" name="transform"/>
+          <FRBRauthor href="#tna"/>
+          <FRBRformat value="application/xml"/>
+        </FRBRManifestation>
+      </identification>
+      <proprietary source="#">
+        <uk:cite>[2022] EWHC 103 (Ch)</uk:cite>
+        <uk:court>EWHC-Chancery</uk:court>
+      </proprietary>
+    </meta>
+    <header>
+      <p>pagination d</p>
+    </header>
+    <judgmentBody>
+      <decision>
+        <p>unique keyword for pagination tests: paginationfixture</p>
+      </decision>
+    </judgmentBody>
+  </judgment>
+</akomaNtoso>

--- a/src/test/ml-modules/root/test/suites/SearchPagination/test-data/page-e.xml
+++ b/src/test/ml-modules/root/test/suites/SearchPagination/test-data/page-e.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
+  <judgment name="decision">
+    <meta>
+      <identification source="#tna">
+        <FRBRWork>
+          <FRBRthis value="https://caselaw.nationalarchives.gov.uk/id/pagination/e"/>
+          <FRBRuri value="https://caselaw.nationalarchives.gov.uk/id/pagination/e"/>
+          <FRBRdate date="2023-01-01" name="decision"/>
+          <FRBRauthor href="#"/>
+          <FRBRcountry value="GB-UKM"/>
+          <FRBRnumber value=""/>
+          <FRBRname value="Pagination e"/>
+        </FRBRWork>
+        <FRBRExpression>
+          <FRBRthis value="https://caselaw.nationalarchives.gov.uk/pagination/e"/>
+          <FRBRuri value="https://caselaw.nationalarchives.gov.uk/pagination/e"/>
+          <FRBRdate date="2023-01-01" name="decision"/>
+          <FRBRauthor href="#"/>
+          <FRBRlanguage language="eng"/>
+        </FRBRExpression>
+        <FRBRManifestation>
+          <FRBRthis value="https://caselaw.nationalarchives.gov.uk/pagination/e/data.xml"/>
+          <FRBRuri value="https://caselaw.nationalarchives.gov.uk/pagination/e/data.xml"/>
+          <FRBRdate date="2023-01-01T12:00:00" name="transform"/>
+          <FRBRauthor href="#tna"/>
+          <FRBRformat value="application/xml"/>
+        </FRBRManifestation>
+      </identification>
+      <proprietary source="#">
+        <uk:cite>[2023] EWHC 104 (Ch)</uk:cite>
+        <uk:court>EWHC-Chancery</uk:court>
+      </proprietary>
+    </meta>
+    <header>
+      <p>pagination e</p>
+    </header>
+    <judgmentBody>
+      <decision>
+        <p>unique keyword for pagination tests: paginationfixture</p>
+      </decision>
+    </judgmentBody>
+  </judgment>
+</akomaNtoso>

--- a/src/test/ml-modules/root/test/suites/SearchPagination/test-data/page-f.xml
+++ b/src/test/ml-modules/root/test/suites/SearchPagination/test-data/page-f.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
+  <judgment name="decision">
+    <meta>
+      <identification source="#tna">
+        <FRBRWork>
+          <FRBRthis value="https://caselaw.nationalarchives.gov.uk/id/pagination/f"/>
+          <FRBRuri value="https://caselaw.nationalarchives.gov.uk/id/pagination/f"/>
+          <FRBRdate date="2024-01-01" name="decision"/>
+          <FRBRauthor href="#"/>
+          <FRBRcountry value="GB-UKM"/>
+          <FRBRnumber value=""/>
+          <FRBRname value="Pagination f"/>
+        </FRBRWork>
+        <FRBRExpression>
+          <FRBRthis value="https://caselaw.nationalarchives.gov.uk/pagination/f"/>
+          <FRBRuri value="https://caselaw.nationalarchives.gov.uk/pagination/f"/>
+          <FRBRdate date="2024-01-01" name="decision"/>
+          <FRBRauthor href="#"/>
+          <FRBRlanguage language="eng"/>
+        </FRBRExpression>
+        <FRBRManifestation>
+          <FRBRthis value="https://caselaw.nationalarchives.gov.uk/pagination/f/data.xml"/>
+          <FRBRuri value="https://caselaw.nationalarchives.gov.uk/pagination/f/data.xml"/>
+          <FRBRdate date="2024-01-01T12:00:00" name="transform"/>
+          <FRBRauthor href="#tna"/>
+          <FRBRformat value="application/xml"/>
+        </FRBRManifestation>
+      </identification>
+      <proprietary source="#">
+        <uk:cite>[2024] EWHC 105 (Ch)</uk:cite>
+        <uk:court>EWHC-Chancery</uk:court>
+      </proprietary>
+    </meta>
+    <header>
+      <p>pagination f</p>
+    </header>
+    <judgmentBody>
+      <decision>
+        <p>unique keyword for pagination tests: paginationfixture</p>
+      </decision>
+    </judgmentBody>
+  </judgment>
+</akomaNtoso>

--- a/src/test/ml-modules/root/test/suites/SearchQuery/helper-tests.xqy
+++ b/src/test/ml-modules/root/test/suites/SearchQuery/helper-tests.xqy
@@ -2,12 +2,83 @@ xquery version '1.0-ml';
 
 import module namespace test = 'http://marklogic.com/test' at '/test/test-helper.xqy';
 import module namespace helper = "https://caselaw.nationalarchives.gov.uk/helper" at "/judgments/search/helper.xqy";
+import module namespace search = "http://marklogic.com/appservices/search" at "/MarkLogic/appservices/search/search.xqy";
 
+declare variable $uri as xs:string := "/test/add-properties-identifiers.xml";
 
+declare variable $identifiers as element(identifiers) :=
+  <identifiers>
+    <identifier>
+      <namespace>fclid</namespace>
+      <uuid>id-test-fclid</uuid>
+      <value>tn4t35ts</value>
+      <url_slug>test/add-properties-identifiers</url_slug>
+    </identifier>
+  </identifiers>;
 
-test:assert-true(fn:empty(helper:add-properties-to-search(()))),
-test:assert-equal("Adams v Brown", helper:normalise-vs("Adams -v- Brown")),
-test:assert-equal("Charles v Daniels", helper:normalise-vs("Charles - v - Daniels")),
-test:assert-equal("Edwards v Finlay", helper:normalise-vs("Edwards V Finlay")),
-test:assert-equal("Gonzalez v Hughes", helper:normalise-vs("Gonzalez vs Hughes")),
-test:assert-equal("Veronica Avalos v Vincent Havering &amp; VsVs Ltd.", helper:normalise-vs("Veronica Avalos v Vincent Havering &amp; VsVs Ltd."))
+declare variable $search-with-body as element(search:response) :=
+  <search:response xmlns:search="http://marklogic.com/appservices/search" total="1">
+    <search:result uri="{$uri}" index="1">
+      <search:snippet/>
+      <search:extracted kind="element">
+        <name>Example</name>
+      </search:extracted>
+    </search:result>
+  </search:response>;
+
+declare function local:eval-update($query as xs:string, $vars as map:map) {
+  xdmp:eval(
+    $query,
+    $vars,
+    <options xmlns="xdmp:eval">
+      <isolation>different-transaction</isolation>
+      <update>true</update>
+    </options>
+  )
+};
+
+declare function local:eval-query($query as xs:string, $vars as map:map) {
+  xdmp:eval(
+    $query,
+    $vars,
+    <options xmlns="xdmp:eval">
+      <isolation>different-transaction</isolation>
+    </options>
+  )
+};
+
+let $_ := local:eval-update(
+  'declare variable $uri as xs:string external;
+   declare variable $identifiers as element(identifiers) external;
+   xdmp:document-insert($uri, <doc><title>Helper Fixture</title></doc>),
+   xdmp:document-set-properties($uri, $identifiers)',
+  map:map() => map:with("uri", $uri) => map:with("identifiers", $identifiers)
+)
+
+(: Hydrate + amalgamate in a fresh transaction so the fixture is visible. :)
+let $amalgamated := local:eval-query(
+  'import module namespace helper = "https://caselaw.nationalarchives.gov.uk/helper" at "/judgments/search/helper.xqy";
+   declare variable $search as element() external;
+   declare variable $uri as xs:string external;
+   helper:amalgamate-identifiers($search, helper:hydrate-identifiers($uri))',
+  map:map() => map:with("search", $search-with-body) => map:with("uri", $uri)
+)
+
+let $_ := local:eval-update(
+  'declare variable $uri as xs:string external;
+   if (fn:doc-available($uri)) then xdmp:document-delete($uri) else ()',
+  map:map() => map:with("uri", $uri)
+)
+
+return (
+  test:assert-true(fn:empty(helper:amalgamate-identifiers((), map:map()))),
+  test:assert-equal("Adams v Brown", helper:normalise-vs("Adams -v- Brown")),
+  test:assert-equal("Charles v Daniels", helper:normalise-vs("Charles - v - Daniels")),
+  test:assert-equal("Edwards v Finlay", helper:normalise-vs("Edwards V Finlay")),
+  test:assert-equal("Gonzalez v Hughes", helper:normalise-vs("Gonzalez vs Hughes")),
+  test:assert-equal("Veronica Avalos v Vincent Havering &amp; VsVs Ltd.", helper:normalise-vs("Veronica Avalos v Vincent Havering &amp; VsVs Ltd.")),
+  test:assert-equal(1, fn:count($amalgamated//search:extracted[@kind="identifiers"])),
+  test:assert-equal("tn4t35ts", string($amalgamated//search:extracted[@kind="identifiers"]//value)),
+  test:assert-equal(1, fn:count($amalgamated//identifiers)),
+  test:assert-equal("Example", string($amalgamated//search:extracted[@kind="element"]/name))
+)

--- a/src/test/ml-modules/root/test/suites/SearchQuery/keyword-matching-tests.xqy
+++ b/src/test/ml-modules/root/test/suites/SearchQuery/keyword-matching-tests.xqy
@@ -1,0 +1,29 @@
+xquery version '1.0-ml';
+
+import module namespace test = 'http://marklogic.com/test' at '/test/test-helper.xqy';
+import module namespace search = "http://marklogic.com/appservices/search" at "/MarkLogic/appservices/search/search.xqy";
+import module namespace search-test = "https://caselaw.nationalarchives.gov.uk/test/search" at "/test/lib/search-test-helper.xqy";
+
+declare function local:uris($response) as xs:string* {
+  for $r in $response//search:result return string($r/@uri)
+};
+
+let $shared := search-test:search(map:entry("q", "queryfixture"))
+let $shared-uris := local:uris($shared)
+
+let $alpha := search-test:search(map:entry("q", "queryalpha"))
+let $alpha-uris := local:uris($alpha)
+
+let $none := search-test:search(map:entry("q", "no-such-token-xyz"))
+
+return (
+  test:assert-equal("2", string($shared//@total)),
+  test:assert-true($shared-uris = "/query/alpha.xml"),
+  test:assert-true($shared-uris = "/query/beta.xml"),
+  test:assert-equal(2, fn:count($shared-uris)),
+
+  test:assert-equal("1", string($alpha//@total)),
+  test:assert-equal("/query/alpha.xml", $alpha-uris[1]),
+
+  test:assert-equal("0", string($none//@total))
+)

--- a/src/test/ml-modules/root/test/suites/SearchQuery/query-html-representation-tests.xqy
+++ b/src/test/ml-modules/root/test/suites/SearchQuery/query-html-representation-tests.xqy
@@ -15,7 +15,8 @@ let $with_and_without_html_response := search-test:search(
     => map:with("only_with_html_representation", fn:false())
 )
 
+(: Suite fixtures: sample judgment, PDF, query-alpha, query-beta. :)
 return (
-  test:assert-equal("1", string($only_with_html_response//@total)),
-  test:assert-equal("2", string($with_and_without_html_response//@total))
+  test:assert-equal("3", string($only_with_html_response//@total)),
+  test:assert-equal("4", string($with_and_without_html_response//@total))
 )

--- a/src/test/ml-modules/root/test/suites/SearchQuery/suite-setup.xqy
+++ b/src/test/ml-modules/root/test/suites/SearchQuery/suite-setup.xqy
@@ -1,16 +1,43 @@
 xquery version '1.0-ml';
 
 import module namespace test = 'http://marklogic.com/test' at '/test/test-helper.xqy';
+import module namespace dls = "http://marklogic.com/xdmp/dls" at "/MarkLogic/dls.xqy";
 
-(:
-   Runs once when your suite is started.
-   You can use this to insert some data that will not be modified over the course of the suite's tests.
-   If no suite-specific setup is required, this file may be deleted.
-:)
+declare function local:publish-judgment($uri as xs:string) as empty-sequence() {
+  if (fn:not(dls:document-is-managed($uri))) then
+    dls:document-manage($uri, fn:true())
+  else (),
+  dls:document-set-permissions(
+    $uri,
+    (
+      xdmp:permission("caselaw-reader", "read"),
+      xdmp:permission("caselaw-reader", "update"),
+      xdmp:permission("dls-user", "read"),
+      xdmp:permission("dls-user", "update")
+    )
+  ),
+  xdmp:document-add-properties($uri, <published>true</published>),
+  xdmp:document-add-collections($uri, "judgment")
+};
 
-let $x := test:load-test-file("sample_judgment.xml", xdmp:database(), "/ewhc/ch/1234/5678.xml")
-let $x := test:load-test-file("pdf-test-content.xml", xdmp:database(), "/pdf/1234/5678.xml")
-let $x := xdmp:document-set-collections("/ewhc/ch/1234/5678.xml", ("judgments", "http://marklogic.com/collections/dls/latest-version"))
-let $x := xdmp:document-set-collections("/pdf/1234/5678.xml", ("judgments", "http://marklogic.com/collections/dls/latest-version"))
-let $x := test:log("SampleTestSuite Suite Setup COMPLETE....")
-return ()
+let $collections := ("judgments", "judgment", "http://marklogic.com/collections/dls/latest-version")
+
+(: Existing fixtures for extract/highlight and HTML-representation tests. :)
+let $_ := test:load-test-file("sample_judgment.xml", xdmp:database(), "/ewhc/ch/1234/5678.xml")
+let $_ := xdmp:document-set-collections("/ewhc/ch/1234/5678.xml", $collections)
+let $_ := local:publish-judgment("/ewhc/ch/1234/5678.xml")
+
+let $_ := test:load-test-file("pdf-test-content.xml", xdmp:database(), "/pdf/1234/5678.xml")
+let $_ := xdmp:document-set-collections("/pdf/1234/5678.xml", $collections)
+let $_ := local:publish-judgment("/pdf/1234/5678.xml")
+
+(: Keyword include/exclude fixtures. :)
+let $_ := test:load-test-file("query-alpha.xml", xdmp:database(), "/query/alpha.xml")
+let $_ := xdmp:document-set-collections("/query/alpha.xml", $collections)
+let $_ := local:publish-judgment("/query/alpha.xml")
+
+let $_ := test:load-test-file("query-beta.xml", xdmp:database(), "/query/beta.xml")
+let $_ := xdmp:document-set-collections("/query/beta.xml", $collections)
+let $_ := local:publish-judgment("/query/beta.xml")
+
+return test:log("SearchQuery Suite Setup COMPLETE....")

--- a/src/test/ml-modules/root/test/suites/SearchQuery/test-data/query-alpha.xml
+++ b/src/test/ml-modules/root/test/suites/SearchQuery/test-data/query-alpha.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
+  <judgment name="decision">
+    <meta>
+      <identification source="#tna">
+        <FRBRWork>
+          <FRBRthis value="https://caselaw.nationalarchives.gov.uk/id/query/alpha"/>
+          <FRBRuri value="https://caselaw.nationalarchives.gov.uk/id/query/alpha"/>
+          <FRBRdate date="2021-03-01" name="decision"/>
+          <FRBRauthor href="#"/>
+          <FRBRcountry value="GB-UKM"/>
+          <FRBRnumber value=""/>
+          <FRBRname value="Query Alpha Fixture"/>
+        </FRBRWork>
+        <FRBRExpression>
+          <FRBRthis value="https://caselaw.nationalarchives.gov.uk/query/alpha"/>
+          <FRBRuri value="https://caselaw.nationalarchives.gov.uk/query/alpha"/>
+          <FRBRdate date="2021-03-01" name="decision"/>
+          <FRBRauthor href="#"/>
+          <FRBRlanguage language="eng"/>
+        </FRBRExpression>
+        <FRBRManifestation>
+          <FRBRthis value="https://caselaw.nationalarchives.gov.uk/query/alpha/data.xml"/>
+          <FRBRuri value="https://caselaw.nationalarchives.gov.uk/query/alpha/data.xml"/>
+          <FRBRdate date="2021-03-01T10:00:00" name="transform"/>
+          <FRBRauthor href="#tna"/>
+          <FRBRformat value="application/xml"/>
+        </FRBRManifestation>
+      </identification>
+      <proprietary source="#">
+        <uk:cite>[2021] EWHC 1 (Ch)</uk:cite>
+        <uk:court>EWHC-Chancery</uk:court>
+      </proprietary>
+    </meta>
+    <header>
+      <p>query alpha fixture</p>
+    </header>
+    <judgmentBody>
+      <decision>
+        <p>shared keyword queryfixture and unique keyword queryalpha</p>
+      </decision>
+    </judgmentBody>
+  </judgment>
+</akomaNtoso>

--- a/src/test/ml-modules/root/test/suites/SearchQuery/test-data/query-beta.xml
+++ b/src/test/ml-modules/root/test/suites/SearchQuery/test-data/query-beta.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
+  <judgment name="decision">
+    <meta>
+      <identification source="#tna">
+        <FRBRWork>
+          <FRBRthis value="https://caselaw.nationalarchives.gov.uk/id/query/beta"/>
+          <FRBRuri value="https://caselaw.nationalarchives.gov.uk/id/query/beta"/>
+          <FRBRdate date="2021-04-01" name="decision"/>
+          <FRBRauthor href="#"/>
+          <FRBRcountry value="GB-UKM"/>
+          <FRBRnumber value=""/>
+          <FRBRname value="Query Beta Fixture"/>
+        </FRBRWork>
+        <FRBRExpression>
+          <FRBRthis value="https://caselaw.nationalarchives.gov.uk/query/beta"/>
+          <FRBRuri value="https://caselaw.nationalarchives.gov.uk/query/beta"/>
+          <FRBRdate date="2021-04-01" name="decision"/>
+          <FRBRauthor href="#"/>
+          <FRBRlanguage language="eng"/>
+        </FRBRExpression>
+        <FRBRManifestation>
+          <FRBRthis value="https://caselaw.nationalarchives.gov.uk/query/beta/data.xml"/>
+          <FRBRuri value="https://caselaw.nationalarchives.gov.uk/query/beta/data.xml"/>
+          <FRBRdate date="2021-04-01T10:00:00" name="transform"/>
+          <FRBRauthor href="#tna"/>
+          <FRBRformat value="application/xml"/>
+        </FRBRManifestation>
+      </identification>
+      <proprietary source="#">
+        <uk:cite>[2021] EWHC 2 (Ch)</uk:cite>
+        <uk:court>EWHC-Chancery</uk:court>
+      </proprietary>
+    </meta>
+    <header>
+      <p>query beta fixture</p>
+    </header>
+    <judgmentBody>
+      <decision>
+        <p>shared keyword queryfixture and unique keyword querybeta</p>
+      </decision>
+    </judgmentBody>
+  </judgment>
+</akomaNtoso>

--- a/src/test/ml-modules/root/test/suites/SearchResultData/metadata-for-all-orders-tests.xqy
+++ b/src/test/ml-modules/root/test/suites/SearchResultData/metadata-for-all-orders-tests.xqy
@@ -1,0 +1,50 @@
+xquery version '1.0-ml';
+
+import module namespace test = 'http://marklogic.com/test' at '/test/test-helper.xqy';
+import module namespace search = "http://marklogic.com/appservices/search" at "/MarkLogic/appservices/search/search.xqy";
+import module namespace search-test = "https://caselaw.nationalarchives.gov.uk/test/search" at "/test/lib/search-test-helper.xqy";
+
+declare namespace akn = "http://docs.oasis-open.org/legaldocml/ns/akn/3.0";
+declare namespace uk = "https://caselaw.nationalarchives.gov.uk/akn";
+
+declare function local:assert-result-metadata($response) {
+  let $results := $response//search:result
+  let $element-extracts := $results/search:extracted[(not(@kind) or @kind = "element")]
+  return (
+    test:assert-equal("2", string($response//@total)),
+    test:assert-equal(2, fn:count($results)),
+    test:assert-equal(0, fn:count($results/search:extracted-none)),
+    test:assert-equal(2, fn:count($element-extracts)),
+    test:assert-equal(2, fn:count($element-extracts//akn:FRBRname/@value)),
+    test:assert-equal(2, fn:count($element-extracts//uk:court)),
+    test:assert-equal(2, fn:count($element-extracts//akn:FRBRdate[@name="decision"])),
+    test:assert-equal(2, fn:count($results/search:extracted[@kind="identifiers"])),
+    test:assert-equal(2, fn:count($results/search:extracted[@kind="identifiers"]/identifiers/identifier)),
+    (: Exactly one identifiers root per result. :)
+    test:assert-equal(2, fn:count($results//identifiers))
+  )
+};
+
+declare function local:search($order as xs:string?) {
+  if (fn:empty($order) or $order = "") then
+    search-test:search(map:entry("q", "resultdatafixture"))
+  else
+    search-test:search(
+      map:entry("q", "resultdatafixture") => map:with("order", $order)
+    )
+};
+
+let $orders := ("", "date", "-date", "updated", "-updated", "transformation", "-transformation")
+
+let $assertions :=
+  for $order in $orders
+  return local:assert-result-metadata(local:search($order))
+
+let $public-ui := search-test:search-as-public-ui(
+  map:entry("q", "resultdatafixture") => map:with("order", "updated")
+)
+
+return (
+  $assertions,
+  local:assert-result-metadata($public-ui)
+)

--- a/src/test/ml-modules/root/test/suites/SearchResultData/metadata-for-all-orders-tests.xqy
+++ b/src/test/ml-modules/root/test/suites/SearchResultData/metadata-for-all-orders-tests.xqy
@@ -7,19 +7,39 @@ import module namespace search-test = "https://caselaw.nationalarchives.gov.uk/t
 declare namespace akn = "http://docs.oasis-open.org/legaldocml/ns/akn/3.0";
 declare namespace uk = "https://caselaw.nationalarchives.gov.uk/akn";
 
+declare function local:sorted-strings($values as xs:string*) as xs:string* {
+  for $v in $values order by $v return $v
+};
+
 declare function local:assert-result-metadata($response) {
   let $results := $response//search:result
   let $element-extracts := $results/search:extracted[(not(@kind) or @kind = "element")]
+  let $titles := local:sorted-strings(
+    for $v in $element-extracts//akn:FRBRname/@value return string($v)
+  )
+  let $courts := local:sorted-strings(
+    for $v in $element-extracts//uk:court return string($v)
+  )
+  let $dates := local:sorted-strings(
+    for $v in $element-extracts//akn:FRBRdate[@name="decision"]/@date return string($v)
+  )
+  let $ids := local:sorted-strings(
+    for $v in $results/search:extracted[@kind="identifiers"]/identifiers/identifier/value return string($v)
+  )
+  let $slugs := local:sorted-strings(
+    for $v in $results/search:extracted[@kind="identifiers"]/identifiers/identifier/url_slug return string($v)
+  )
   return (
     test:assert-equal("2", string($response//@total)),
     test:assert-equal(2, fn:count($results)),
     test:assert-equal(0, fn:count($results/search:extracted-none)),
     test:assert-equal(2, fn:count($element-extracts)),
-    test:assert-equal(2, fn:count($element-extracts//akn:FRBRname/@value)),
-    test:assert-equal(2, fn:count($element-extracts//uk:court)),
-    test:assert-equal(2, fn:count($element-extracts//akn:FRBRdate[@name="decision"])),
+    test:assert-equal(("Result Data One", "Result Data Two"), $titles),
+    test:assert-equal(("EWHC-Chancery", "EWHC-Family"), $courts),
+    test:assert-equal(("2021-05-01", "2022-07-15"), $dates),
     test:assert-equal(2, fn:count($results/search:extracted[@kind="identifiers"])),
-    test:assert-equal(2, fn:count($results/search:extracted[@kind="identifiers"]/identifiers/identifier)),
+    test:assert-equal(("rdoneaaa", "rdtwobbb"), $ids),
+    test:assert-equal(("result-data/one", "result-data/two"), $slugs),
     (: Exactly one identifiers root per result. :)
     test:assert-equal(2, fn:count($results//identifiers))
   )

--- a/src/test/ml-modules/root/test/suites/SearchResultData/suite-setup.xqy
+++ b/src/test/ml-modules/root/test/suites/SearchResultData/suite-setup.xqy
@@ -1,0 +1,46 @@
+xquery version '1.0-ml';
+
+import module namespace test = 'http://marklogic.com/test' at '/test/test-helper.xqy';
+import module namespace dls = "http://marklogic.com/xdmp/dls" at "/MarkLogic/dls.xqy";
+
+declare function local:publish-judgment($uri as xs:string, $fclid as xs:string, $slug as xs:string) as empty-sequence() {
+  if (fn:not(dls:document-is-managed($uri))) then
+    dls:document-manage($uri, fn:true())
+  else (),
+  dls:document-set-permissions(
+    $uri,
+    (
+      xdmp:permission("caselaw-reader", "read"),
+      xdmp:permission("caselaw-reader", "update"),
+      xdmp:permission("dls-user", "read"),
+      xdmp:permission("dls-user", "update")
+    )
+  ),
+  xdmp:document-add-properties(
+    $uri,
+    (
+      <published>true</published>,
+      <identifiers>
+        <identifier>
+          <namespace>fclid</namespace>
+          <uuid>id-{$fclid}</uuid>
+          <value>{$fclid}</value>
+          <url_slug>{$slug}</url_slug>
+        </identifier>
+      </identifiers>
+    )
+  ),
+  xdmp:document-add-collections($uri, "judgment")
+};
+
+let $collections := ("judgments", "judgment", "http://marklogic.com/collections/dls/latest-version")
+
+let $_ := test:load-test-file("result-one.xml", xdmp:database(), "/result-data/one.xml")
+let $_ := xdmp:document-set-collections("/result-data/one.xml", $collections)
+let $_ := local:publish-judgment("/result-data/one.xml", "rdoneaaa", "result-data/one")
+
+let $_ := test:load-test-file("result-two.xml", xdmp:database(), "/result-data/two.xml")
+let $_ := xdmp:document-set-collections("/result-data/two.xml", $collections)
+let $_ := local:publish-judgment("/result-data/two.xml", "rdtwobbb", "result-data/two")
+
+return test:log("SearchResultData Suite Setup COMPLETE....")

--- a/src/test/ml-modules/root/test/suites/SearchResultData/suite-teardown.xqy
+++ b/src/test/ml-modules/root/test/suites/SearchResultData/suite-teardown.xqy
@@ -1,0 +1,6 @@
+xquery version '1.0-ml';
+
+import module namespace test = 'http://marklogic.com/test' at '/test/test-helper.xqy';
+
+for $doc in doc()
+return xdmp:document-delete(xdmp:node-uri($doc))

--- a/src/test/ml-modules/root/test/suites/SearchResultData/test-data/result-one.xml
+++ b/src/test/ml-modules/root/test/suites/SearchResultData/test-data/result-one.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
+  <judgment name="decision">
+    <meta>
+      <identification source="#tna">
+        <FRBRWork>
+          <FRBRthis value="https://caselaw.nationalarchives.gov.uk/id/result-data/one"/>
+          <FRBRuri value="https://caselaw.nationalarchives.gov.uk/id/result-data/one"/>
+          <FRBRdate date="2021-05-01" name="decision"/>
+          <FRBRauthor href="#"/>
+          <FRBRcountry value="GB-UKM"/>
+          <FRBRnumber value=""/>
+          <FRBRname value="Result Data One"/>
+        </FRBRWork>
+        <FRBRExpression>
+          <FRBRthis value="https://caselaw.nationalarchives.gov.uk/result-data/one"/>
+          <FRBRuri value="https://caselaw.nationalarchives.gov.uk/result-data/one"/>
+          <FRBRdate date="2021-05-01" name="decision"/>
+          <FRBRauthor href="#"/>
+          <FRBRlanguage language="eng"/>
+        </FRBRExpression>
+        <FRBRManifestation>
+          <FRBRthis value="https://caselaw.nationalarchives.gov.uk/result-data/one/data.xml"/>
+          <FRBRuri value="https://caselaw.nationalarchives.gov.uk/result-data/one/data.xml"/>
+          <FRBRdate date="2021-05-01T12:00:00" name="transform"/>
+          <FRBRauthor href="#tna"/>
+          <FRBRformat value="application/xml"/>
+        </FRBRManifestation>
+      </identification>
+      <proprietary source="#">
+        <uk:hash>aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</uk:hash>
+        <uk:cite>[2021] EWHC 101 (Ch)</uk:cite>
+        <uk:court>EWHC-Chancery</uk:court>
+      </proprietary>
+    </meta>
+    <header>
+      <p>result data one</p>
+    </header>
+    <judgmentBody>
+      <decision>
+        <p>unique keyword for result data tests: resultdatafixture</p>
+      </decision>
+    </judgmentBody>
+  </judgment>
+</akomaNtoso>

--- a/src/test/ml-modules/root/test/suites/SearchResultData/test-data/result-two.xml
+++ b/src/test/ml-modules/root/test/suites/SearchResultData/test-data/result-two.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
+  <judgment name="decision">
+    <meta>
+      <identification source="#tna">
+        <FRBRWork>
+          <FRBRthis value="https://caselaw.nationalarchives.gov.uk/id/result-data/two"/>
+          <FRBRuri value="https://caselaw.nationalarchives.gov.uk/id/result-data/two"/>
+          <FRBRdate date="2022-07-15" name="decision"/>
+          <FRBRauthor href="#"/>
+          <FRBRcountry value="GB-UKM"/>
+          <FRBRnumber value=""/>
+          <FRBRname value="Result Data Two"/>
+        </FRBRWork>
+        <FRBRExpression>
+          <FRBRthis value="https://caselaw.nationalarchives.gov.uk/result-data/two"/>
+          <FRBRuri value="https://caselaw.nationalarchives.gov.uk/result-data/two"/>
+          <FRBRdate date="2022-07-15" name="decision"/>
+          <FRBRauthor href="#"/>
+          <FRBRlanguage language="eng"/>
+        </FRBRExpression>
+        <FRBRManifestation>
+          <FRBRthis value="https://caselaw.nationalarchives.gov.uk/result-data/two/data.xml"/>
+          <FRBRuri value="https://caselaw.nationalarchives.gov.uk/result-data/two/data.xml"/>
+          <FRBRdate date="2022-07-15T12:00:00" name="transform"/>
+          <FRBRauthor href="#tna"/>
+          <FRBRformat value="application/xml"/>
+        </FRBRManifestation>
+      </identification>
+      <proprietary source="#">
+        <uk:hash>bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb</uk:hash>
+        <uk:cite>[2022] EWHC 202 (Fam)</uk:cite>
+        <uk:court>EWHC-Family</uk:court>
+      </proprietary>
+    </meta>
+    <header>
+      <p>result data two</p>
+    </header>
+    <judgmentBody>
+      <decision>
+        <p>unique keyword for result data tests: resultdatafixture</p>
+      </decision>
+    </judgmentBody>
+  </judgment>
+</akomaNtoso>


### PR DESCRIPTION
- Fix `order=updated` so results correctly get title, court, date, and identifiers instead of empty/`extracted-none` results (causing 500s).
- Order the page via the `prop:last-modified` range index on properties fragments, hydrate body extracts with a documents-scoped `search:resolve`, then batch-attach identifiers for results.
- Add supporting test suites covering behaviours we actually care about, including existing ones like "does this actually search".