### PR TITLE
[FCLC-2260] Index latest_metadata_materialisation_version property

### DIFF
--- a/src/main/ml-config/databases/content-database.json
+++ b/src/main/ml-config/databases/content-database.json
@@ -54,6 +54,14 @@
       "localname": "transfer-received-at",
       "range-value-positions": false,
       "invalid-values": "ignore"
+    },
+    {
+      "scalar-type": "string",
+      "namespace-uri": "",
+      "localname": "latest_metadata_materialisation_version",
+      "collation": "http://marklogic.com/collation/",
+      "range-value-positions": false,
+      "invalid-values": "ignore"
     }
   ],
   "word-positions": true,


### PR DESCRIPTION
Add a string `range-element-index` on document property `latest_metadata_materialisation_version` to enable maintenance queries for documents that have not been materialised under the current metadata logic version

API client change: https://github.com/nationalarchives/ds-caselaw-custom-api-client/pull/2036

## Jira
FCLC-2260