### PR TITLE
Fix TDE views being admin-only after mlDeploy

### DIFF
--- a/src/main/ml-config/databases/content-database.json
+++ b/src/main/ml-config/databases/content-database.json
@@ -2,6 +2,7 @@
   "database-name": "%%DATABASE%%",
   "schema-database": "%%SCHEMAS_DATABASE%%",
   "triggers-database": "%%TRIGGERS_DATABASE%%",
+  "triple-index": true,
   "path-namespace": [
     {
       "prefix": "akn",

--- a/src/main/ml-config/security/roles/caselaw-execute-sql-role.json
+++ b/src/main/ml-config/security/roles/caselaw-execute-sql-role.json
@@ -1,7 +1,7 @@
 {
   "role-name": "caselaw-execute-sql",
   "description": "Can execute SQL queries against the database over XDMP",
-  "role": [],
+  "role": ["tde-view"],
   "privilege": [
     {
       "privilege-name": "can-execute-sql",

--- a/src/main/ml-schemas/tde/permissions.properties
+++ b/src/main/ml-schemas/tde/permissions.properties
@@ -1,0 +1,5 @@
+# TDE row/view access inherits read permissions from the template document.
+# Deploying as admin without permissions leaves templates admin-only, so
+# get_highest_parser_version (and other SQL against TDE views) breaks for app users
+# until someone re-saves the template in Query Console.
+*=rest-reader,read,tde-view,read


### PR DESCRIPTION
- Give TDE templates explicit `rest-reader`/`tde-view` read permissions on deploy so SQL views (e.g. `documents.process_data` used by `get_highest_parser_version`) stay visible to app users after `mlDeploy`
- Add the built-in `tde-view` role to `caselaw-execute-sql` (inherited by EUI via `caselaw-reader`)
- Persist `triple-index: true` on the content database in config (required for TDE; already enabled manually in live envs)